### PR TITLE
Add #isTv() to properly detect common TVs

### DIFF
--- a/Mobile_Detect.php
+++ b/Mobile_Detect.php
@@ -358,6 +358,33 @@ class Mobile_Detect
     );
 
     /**
+     * List of tv devices. Experimental.
+     *
+     * @var array
+     */
+    protected static $tvDevices = array(
+        'Apple'         => 'AppleTV',
+        'Google'        => 'GoogleTV|CrKey',
+        'LG'            => 'NetCast|LGSmartTV|HbbTV.+LGE?',
+        'Sony'          => 'SonyDTV|SonyBDP|SonyCEBrowser|HbbTV.+Sony',
+        'Samsung'       => 'SMART-?TV',
+        'Panasonic'     => 'Viera',
+        'Philips'       => 'NETTV/',
+        'Roku'          => 'Roku/DVP',
+        'Sharp'         => 'AQUOSBrowser|AQUOS-AS',
+        'Smart'         => 'HbbTV.+smart',
+        'Technicolor'   => 'Technicolor_',
+        'TechniSat'     => 'TechniSat',
+        'Toshiba'       => 'Toshiba_?TP|TSBNetTV/|HbbTV.+TOSHIBA',
+        'TV2N'          => 'HbbTV.+tv2n',
+        'Motorola'      => 'Motorola KreaTV STB',
+        'Winbox'        => 'Winbox Evo2',
+        'Dune HD'       => 'DuneHD/',
+        'Bewatec'       => 'MediStream',
+        'Other'         => 'NETRANGEMMH|mbxtWebKit/|MachBlue|POV_TV|HbbTV|Kylo/|ADB;|Mstar;OWB|InettvBrowser|Opera[ -]TV|Boxee|Espial/|ANTGalio/|Web[0O]S.+Large Screen',
+    );
+
+    /**
      * List of mobile Operating Systems.
      *
      * @var array
@@ -962,6 +989,25 @@ class Mobile_Detect
 
         foreach (self::$tabletDevices as $_regex) {
             if ($this->match($_regex, $userAgent)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the device is a tv.
+     * Return true if any type of tv device is detected.
+     *
+     * @return bool
+     */
+    public function isTv()
+    {
+        $this->setDetectionType(self::DETECTION_TYPE_EXTENDED);
+
+        foreach (self::$tvDevices as $_regex) {
+            if ($this->match($_regex)) {
                 return true;
             }
         }

--- a/tests/UA_List.inc.php
+++ b/tests/UA_List.inc.php
@@ -876,8 +876,116 @@ return array(
         'SonyEricssonU5i/R2CA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525' => array('isMobile' => true, 'isTablet' => false),
         'SonyEricssonU5i/R2AA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525' => array('isMobile' => true, 'isTablet' => false),
         'Mozilla/4.0 (PDA; PalmOS/sony/model prmr/Revision:1.1.54 (en)) NetFront/3.0'                                                                                           => array('isMobile' => true, 'isTablet' => false),
-        'Opera/9.80 (Linux mips; U; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC/BEL; en) Presto/2.7.61 Version/11.00'                                        => array('isMobile' => false, 'isTablet' => false),
-        'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'                                                       => array('isMobile' => false, 'isTablet' => false),
+        'Opera/9.80 (Linux mips; U; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC/BEL; en) Presto/2.7.61 Version/11.00'                                        => array('isTv' => true),
+        'Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11'                                                       => array('isTv' => true),
+        ),
+
+    'Apple' => array(
+        'iTunes-AppleTV/4.1' => array('isTv' => true),
+        ),
+
+    'Google' => array(
+        'Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.127 Large Screen Safari/533.4 GoogleTV/ 162671' => array('isTv' => true),
+        'Mozilla/5.0 (X11; U: Linux i686; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.127 Large Screen Safari/533.4 GoogleTV/b39389' => array('isTv' => true),
+        'CrKey' => array('isTv' => true),
+        ),
+
+    'LG' => array(
+        'Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+SCREEN+TUNER; LGE; 42LW5700-SA; 04.02.28; 0x00000001;); LG NetCast.TV-2011' => array('isTv' => true),
+        'Mozilla/5.0 (DirectFB; U; Linux mips; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.0.10(+SCREEN+TUNER; LGE; 42LE5500-SA; 04.02.02; 0x00000001;); LG NetCast.TV-2010' => array('isTv' => true),
+        'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; GLOBAL-PLAT5; 03.07.01; 0x00000001;); LG NetCast.TV-2013/03.17.01 (LG, GLOBAL-PLAT4, wired)' => array('isTv' => true),
+        'Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)' => array('isTv' => true),
+        'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LG Electronics ;NetCast 3.0 ;1.0 ;1.0M ;)' => array('isTv' => true),
+        'Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)' => array('isTv' => true),
+        ),
+
+    'Panasonic' => array(
+        'Mozilla/5.0 (FreeBSD; U; Viera; ja-JP) AppleWebKit/535.1 (KHTML, like Gecko) Viera/1.2.4 Chrome/14.0.835.202 Safari/535.1'                                                       => array('isTv' => true),
+        ),
+
+    'Philips' => array(
+        'Opera/9.70 (Linux armv6l ; U; CE-HTML/1.0 NETTV/2.0.2; en) Presto/2.2.1'                                                       => array('isTv' => true),
+        'Opera/9.80 (Linux armv6l ; U; CE-HTML/1.0 NETTV/3.0.1;; en) Presto/2.6.33 Version/10.60'                                                       => array('isTv' => true),
+        'Opera/9.80 (Linux mips; HbbTV/1.2.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.2.0 PHILIPSTV/1.1.1 Firmware/171.56.0 (PhilipsTV, 1.1.1,) en) Presto/2.12.362 Version/12.11'                                                       => array('isTv' => true),
+        ),
+
+    'Roku' => array(
+        'Roku/DVP-5.2 (025.02E03197A)'                                                       => array('isTv' => true),
+        'Roku/DVP-5.0 (025.00E08043A)'                                                       => array('isTv' => true),
+        ),
+
+    'Samsung' => array(
+        'HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit'                                                       => array('isTv' => true),
+        'Mozilla/5.0 (SmartHub; SMART-TV; U; Linux/SmartTV) AppleWebKit/531.2+ (KHTML, like Gecko) WebBrowser/1.0 SmartTV Safari/531.2+'                                                       => array('isTv' => true),
+        'Mozilla/5.0 (SMART-TV; X11; Linux i686) AppleWebKit/535.20+ (KHTML, like Gecko) Version/5.0 Safari/535.20+'                                                       => array('isTv' => true),
+        'Mozilla/5.0 (SmartHub; SMART-TV; U; Linux/SmartTV; Maple2012)'                                                       => array('isTv' => true),
+        ),
+
+    'Sharp' => array(
+        'Mozilla/5.0 (DTV) AppleWebKit/531.2  (KHTML, like Gecko) AQUOSBrowser/1.0 (US00DTV;V;0001;0001)' => array('isTv' => true),
+        'Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.0.4 AQUOSBrowser/1.0 (CH00DTV;V;0001;0001)' => array('isTv' => true),
+        'Opera/9.80 (Linux armv6l; U; en) Presto/2.8.115 Version/11.10 AQUOS-AS/1.0 LC-40LE835X' => array('isTv' => true),
+        'Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.1.5 AQUOSBrowser/2.0 (US01DTV;V;0001;0001)'                                                       => array('isTv' => true),
+        ),
+
+    'TechniSat' => array(
+        'Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S; de) Presto/2.9.167 Version/11.50'                                                       => array('isTv' => true),
+        ),
+
+    'Technicolor' => array(
+        'Technicolor_' => array('isTv' => true),
+        ),
+
+    'Toshiba' => array(
+        'Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_RL953; 56.7.66.7; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+NATIVELAUNCH) ; en) AppleWebKit/534.1 (KHTML, like Gecko)' => array('isTv' => true),
+        'Mozilla/5.0 (DTV; TSBNetTV/T32013713.0203.7DD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T32013713;0203;7DD) InettvBrowser/2.2 (000039;T32013713;0203;7DD)' => array('isTv' => true),
+        'Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; 40PX200; 0.7.3.0.; t12; ) ; Toshiba_TP/1.3.0 (+VIDEO_MP4+AUDIO_MPEG+AUDIO_MP4+VIDEO_X_MS_ASF+OFFLINEAPP) ; en) AppleWebKit/534.1 (KHTML, like Gec' => array('isTv' => true),
+        'Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; 40PX200; 0.7.3.0.; t12; ) ; (+VIDEO_MP4+AUDIO_MPEG+AUDIO_MP4+VIDEO_X_MS_ASF+OFFLINEAPP) ; en) AppleWebKit/534.1 (KHTML, like Gec' => array('isTv' => true),
+        ),
+
+    'Smart' => array(
+        'Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; smart; 40PX200; 0.7.3.0.; t12; ) ; AppleWebKit/534.1 (KHTML, like Gec' => array('isTv' => true),
+        ),
+
+    'TV2N' => array(
+        'Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; tv2n; 40PX200; 0.7.3.0.; t12; ) ; AppleWebKit/534.1 (KHTML, like Gec' => array('isTv' => true),
+        ),
+
+    'Motorola' => array(
+        'Motorola KreaTV STB' => array('isTv' => true),
+        ),
+
+    'Winbox' => array(
+        'Winbox Evo2' => array('isTv' => true),
+        ),
+
+    'Dune HD' => array(
+        'DuneHD/' => array('isTv' => true),
+        ),
+
+    'Bewatec' => array(
+        'MediStream' => array('isTv' => true),
+        ),
+
+    'Other' => array(
+        'NETRANGEMMH' => array('isTv' => true),
+        'mbxtWebKit/' => array('isTv' => true),
+        'MachBlue' => array('isTv' => true),
+        'POV_TV' => array('isTv' => true),
+        'Opera/9.80 (Linux sh4; U; ; en; CreNova Build) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1 HbbTV/1.1 (;CreNova;CNV001;1.0;1.0; FXM-U2FsdGVkX19AfSGBrU5pNwqodai+lZp2xktKFNHDE46SbYGa7Wp+eG5Z56WMDCQu-END; en) Presto/2.9 Version' => array('isTv' => true),
+        'Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.4 (KHTML, like Gecko) MWB/1.0 Safari/537.4 HbbTV/1.2.1 (; Mstar; MWB;;;)' => array('isTv' => true),
+        'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2) Gecko/20100222 Firefox/3.6 Kylo/0.6.1.70394' => array('isTv' => true),
+        'ADB;' => array('isTv' => true),
+        'Mstar;OWB' => array('isTv' => true),
+        'InettvBrowser' => array('isTv' => true),
+        'Opera TV' => array('isTv' => true),
+        'Opera-TV' => array('isTv' => true),
+        'Boxee' => array('isTv' => true),
+        'LG Browser' => array('isTv' => true),
+        'Espial/' => array('isTv' => true),
+        'ANTGalio/' => array('isTv' => true),
+        'Web0S dasd asd Large Screen' => array('isTv' => true),
+        'WebOS dasd asd Large Screen' => array('isTv' => true),
         ),
 
     'Skk' => array('Mozilla/5.0 (Linux; U; Android 4.1; en-us; CYCLOPS Build/F10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30' => array('isMobile' => true, 'isTablet' => true)),

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -94,6 +94,10 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
                     $tmp['tablet'] = $props['isTablet'];
                 }
 
+                if (isset($props['isTv'])) {
+                    $tmp['tv'] = $props['isTv'];
+                }
+
                 if (isset($props['version'])) {
                     $tmp['version'] = $props['version'];
                 }
@@ -139,6 +143,7 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
             $tmp[] = isset($userAgent['user_agent']) ? $userAgent['user_agent'] : null;
             $tmp[] = isset($userAgent['mobile']) ? $userAgent['mobile'] : null;
             $tmp[] = isset($userAgent['tablet']) ? $userAgent['tablet'] : null;
+            $tmp[] = isset($userAgent['tv']) ? $userAgent['tv'] : null;
             $tmp[] = isset($userAgent['version']) ? $userAgent['version'] : null;
             $tmp[] = isset($userAgent['model']) ? $userAgent['model'] : null;
             $tmp[] = isset($userAgent['vendor']) ? $userAgent['vendor'] : null;
@@ -158,10 +163,12 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider userAgentData
      */
-    public function testUserAgents($userAgent, $isMobile, $isTablet, $version, $model, $vendor)
+    public function testUserAgents($userAgent, $isMobile, $isTablet, $isTv, $version, $model, $vendor)
     {
         //make sure we're passed valid data
-        if (!is_string($userAgent) || !is_bool($isMobile) || !is_bool($isTablet)) {
+        if (!is_string($userAgent) ||
+          // We need either both isMobile and isTablet or isTv
+          (!(is_bool($isMobile) && is_bool($isTablet)) && !is_bool($isTv))) {
             $this->markTestIncomplete("The User-Agent $userAgent does not have sufficient information for testing.");
 
             return;
@@ -172,10 +179,13 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
         $md->setUserAgent($userAgent);
 
         //is mobile?
-        $this->assertEquals($md->isMobile(), $isMobile);
+        if (!is_null($isMobile)) $this->assertEquals($md->isMobile(), $isMobile);
 
         //is tablet?
-        $this->assertEquals($md->isTablet(), $isTablet);
+        if (!is_null($isTablet)) $this->assertEquals($md->isTablet(), $isTablet);
+
+        //is tv?
+        if (!is_null($isTv)) $this->assertEquals($md->isTv(), $isTv);
 
         if (isset($version)) {
             foreach ($version as $condition => $assertion) {

--- a/tests/ualist.json
+++ b/tests/ualist.json
@@ -1,1 +1,3582 @@
-{"hash":"5214f8038ec952be9987eb876a708750a1e43b31","user_agents":[{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; A100 Build\/HTK55D) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1; en-us; A110 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Webkit":"534.30","Safari":"4.0","Build":"IML74K"},"model":"A200"},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; A701 Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; B1-710 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; A1-810 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; nl-nl; A1-810 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)","mobile":true,"tablet":false},{"vendor":"Acer","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; A3-A10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"JDQ39","Webkit":"537.36","Chrome":"32.0.1700.99"}},{"vendor":"AdvanDigital","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; E1C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"AdvanDigital","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; T3C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Ainol","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; Ainol Novo8 Advanced Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Ainol","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; Novo10 Hero Build\/20121115) AppleWebKit\/535.19 (KHTML like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Ainol","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; novo9-Spark Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"AllFine","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; FINE7 GENIUS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true,"version":{"Android":"3.2.1","Webkit":"534.13","Safari":"4.0"},"model":"Transformer TF101"},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; asus_laptop Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":false},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Build":"JRO03L","Webkit":"534.30","Safari":"4.0"}},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.1; ME301T Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.2.1","Build":"JOP40D"}},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.1; ME173X Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.2.1","Build":"JOP40D"}},{"vendor":"ASUS","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; TF300T Build\/JDQ39E) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"JDQ39E"}},{"vendor":"Alcatel","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; en-in; MB525 Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Alcatel","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; it-it; ALCATEL ONE TOUCH 918D Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false,"version":{"Android":"2.3.5","Webkit":"533.1","Safari":"4.0","Build":"GRJ90"},"model":"ONE TOUCH 918D"},{"vendor":"Alcatel","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; ALCATEL ONE TOUCH 991 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false,"version":{"Android":"2.3.6","Webkit":"533.1","Safari":"4.0","Build":"GRJ90"},"model":"ONE TOUCH 991"},{"vendor":"Alcatel","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; ALCATEL ONE TOUCH 993D Build\/ICECREAM) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false,"version":{"Android":"4.0.4","Webkit":"534.30","Safari":"4.0","Build":"ICECREAM"},"model":"ONE TOUCH 993D"},{"vendor":"Allview","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; ALLVIEW P5 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Allview","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us ; ALLVIEW SPEEDI Build\/IMM76D) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.5.3.246\/145\/355","mobile":true,"tablet":true},{"vendor":"Allview","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; AllviewCity Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Allview","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ALLVIEWSPEED Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Amazon","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.4 Mobile Safari\/535.19 Silk-Accelerated=true","mobile":true,"tablet":true},{"vendor":"Amazon","user_agent":"Mozilla\/5.0 (Linux; U; en-US) AppleWebKit\/528.5+ (KHTML, like Gecko, Safari\/528.5+) Version\/4.0 Kindle\/3.0 (screen 600x800; rotate)","mobile":true,"tablet":true,"version":{"Webkit":"528.5+","Kindle":"3.0","Safari":"4.0"},"model":"Kindle"},{"vendor":"Amazon","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFOTE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"IML74K","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Amazon","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; WFJWAE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Apple","user_agent":"iTunes\/9.1.1","mobile":false,"tablet":false},{"vendor":"Apple","user_agent":"iTunes\/11.0.2 (Windows; Microsoft Windows 8 x64 Business Edition (Build 9200)) AppleWebKit\/536.27.1","mobile":false,"tablet":false},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit\/537.51.1 (KHTML, like Gecko) Version\/7.0 Mobile\/11A4449d Safari\/9537.53","mobile":true,"tablet":false},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit\/420+ (KHTML, like Gecko) Version\/3.0 Mobile\/1A543 Safari\/419.3","mobile":true,"tablet":false,"version":{"Webkit":"420+","Safari":"3.0"}},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit\/528.18 (KHTML, like Gecko) Version\/4.0 Mobile\/7A341 Safari\/528.16","mobile":true,"tablet":false,"version":{"iOS":"3_0","Webkit":"528.18","Safari":"4.0"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9B206 Safari\/7534.48.3","mobile":true,"tablet":false,"version":{"iOS":"5_1_1","Webkit":"534.46","Mobile":"9B206","Safari":"5.1"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPod; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25","mobile":true,"tablet":false,"version":{"iOS":"6_0","Webkit":"536.26","Mobile":"10A403","Safari":"6.0"},"model":"iPod"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPad; CPU OS 5_1_1 like Mac OS X; en-us) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.80 Mobile\/9B206 Safari\/7534.48.3 (6FF046A0-1BC4-4E7D-8A9D-6BF17622A123)","mobile":true,"tablet":true,"version":{"iOS":"5_1_1","Webkit":"534.46.0","Chrome":"21.0.1180.80","Mobile":"9B206"},"model":"iPad"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A403 Safari\/8536.25","mobile":true,"tablet":true,"version":{"iOS":"6_0","Webkit":"536.26","Safari":"6.0","Mobile":"10A403"},"model":"iPad"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPad; U; CPU OS 4_2_1 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8C148 Safari\/6533.18.5","mobile":true,"tablet":true,"version":{"iOS":"4_2_1","Webkit":"533.17.9","Safari":"5.0.2","Mobile":"8C148"},"model":"iPad"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit\/531.21.10 (KHTML, like Gecko) Version\/4.0.4 Mobile\/7B334b Safari\/531.21.10","mobile":true,"tablet":true,"version":{"iOS":"3_2","Webkit":"531.21.10","Safari":"4.0.4","Mobile":"7B334b"},"model":"iPad"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X; da-dk) AppleWebKit\/534.46.0 (KHTML, like Gecko) CriOS\/21.0.1180.82 Mobile\/10A523 Safari\/7534.48.3","mobile":true,"tablet":false,"version":{"iOS":"6_0_1","Webkit":"534.46.0","Chrome":"21.0.1180.82","Mobile":"10A523"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; CPU iPhone OS 6_0_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10A523 Safari\/8536.25","mobile":true,"tablet":false,"version":{"iOS":"6_0_1","Webkit":"536.26","Safari":"6.0","Mobile":"10A523"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1 like Mac OS X; ru-ru) AppleWebKit\/536.26 (KHTML, like Gecko) CriOS\/23.0.1271.100 Mobile\/10B142 Safari\/8536.25","mobile":true,"tablet":false,"version":{"iOS":"6_1","Webkit":"536.26","Chrome":"23.0.1271.100","Mobile":"10B142"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B329 Safari\/8536.25","mobile":true,"tablet":false,"version":{"iOS":"6_1_3","Webkit":"536.26","Safari":"6.0","Mobile":"10B329"},"model":"iPhone"},{"vendor":"Apple","user_agent":"Mozilla\/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Coast\/1.0.2.62956 Mobile\/10B329 Safari\/7534.48.3","mobile":true,"tablet":true,"version":{"Coast":"1.0.2.62956"}},{"vendor":"Archos","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; Qilive 97R Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Archos","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; Archos 50 Platinum Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Archos","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; ARCHOS 80G9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Archos","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; fr-fr; A101IT Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"AudioSonic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-au; T-17B Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9300; en) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+","mobile":true,"tablet":false,"version":{"Webkit":"534.8+","BlackBerry":"6.0.0.546"},"model":"BlackBerry 9300"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9360; en-US) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.400 Mobile Safari\/534.11+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; he) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.723 Mobile Safari\/534.8+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; en-US) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.448 Mobile Safari\/534.8","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9790; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.714 Mobile Safari\/534.11+","mobile":true,"tablet":false,"version":{"Webkit":"534.11+","BlackBerry":"7.1.0.714"},"model":"BlackBerry 9790"},{"vendor":"BlackBerry","user_agent":"Opera\/9.80 (BlackBerry; Opera Mini\/7.0.29990\/28.2504; U; en) Presto\/2.8.119 Version\/11.10","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9981; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.342 Mobile Safari\/534.11+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9800; en-GB) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9780; es) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.480 Mobile Safari\/534.8","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.0.0.583 Mobile Safari\/534.11","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9860; es) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.576 Mobile Safari\/534.11+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9900; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.1.0.523 Mobile Safari\/534.11","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"BlackBerry8520\/5.0.0.1067 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/603","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"BlackBerry8520\/5.0.0.1036 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/611","mobile":true,"tablet":false,"version":{"BlackBerry":"5.0.0.1036","VendorID":"611"},"model":"BlackBerry8520"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BlackBerry; U; BlackBerry 9220; en) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.337 Mobile Safari\/534.11+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit\/536.2+ (KHTML, like Gecko) Version\/7.2.1.0 Safari\/536.2+","mobile":true,"tablet":true},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.1+ (KHTML, like Gecko) Version\/10.0.0.1337 Mobile Safari\/537.1+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+","mobile":true,"tablet":false},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (BB10; Touch) \/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+","mobile":true,"tablet":false,"version":{"BlackBerry":"10.0.9.2372"}},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true,"version":{"Android":"3.2.1","Webkit":"534.13","Safari":"4.0"},"model":"Transformer TF101"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Webkit":"534.30","Safari":"4.0"},"model":"A200"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Webkit":"534.30","Safari":"4.0"},"model":"A500"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Webkit":"534.30","Safari":"4.0"},"model":"A501"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Webkit":"535.19","Chrome":"18.0.1025.166"},"model":"Transformer"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Webkit":"535.19","Chrome":"18.0.1025.166"},"model":"Transformer Pad TF300T"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.2","Webkit":"534.30","Safari":"4.0","Build":"JZO54K"},"model":"Transformer"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.1.2","Webkit":"535.19","Chrome":"18.0.1025.166"},"model":"B1-A71"},{"vendor":"BlackBerry","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)","mobile":true,"tablet":false,"version":{"Windows Phone OS":"7.5","Trident":"5.0","IE":"9.0"},"model":"Allegro"},{"vendor":"Broncho","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"bq","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Livingstone 2 Build\/1.1.7 20121018-10:33) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"bq","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison Build\/1.1.10-1015 20121230-18:00) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"bq","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; Maxwell Lite Build\/v1.0.0.ICS.maxwell.20120920) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"bq","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-tw; bq Maxwell Plus Build\/1.0.0 20120913-10:39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Casio","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; C771 Build\/C771M120) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"ChangJia","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; TPC97113 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"ChangJia","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; TPC7102 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Coby","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; en-us; MID7010 Build\/FRF85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Coby","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID7048 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Coby","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID8042 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Concorde","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde Tab T10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Concorde","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde tab PLAY Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Cresta","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; nl-nl; CRESTA.CTP888 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Cube","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; CUBE U9GT 2 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Danew","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Dslide 700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"IML74K","Webkit":"534.30","Safari":"4.0"},"model":"Dslide 700"},{"vendor":"DanyTech","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; Genius Tab Q4 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Dell","user_agent":"Mozilla\/5.0 (Linux; U; Android 1.6; en-gb; Dell Streak Build\/Donut AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/ 525.20.1","mobile":true,"tablet":false},{"vendor":"Dell","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; hd-us; Dell Venue Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Dell","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; DELL; Venue Pro)","mobile":true,"tablet":false},{"vendor":"DPS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; DPS Dream 9 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"ECS","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; TM105A Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"IMM76D","Webkit":"534.30"}},{"vendor":"Eboda","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme Dual Core X190 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Eboda","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Essential A160 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Eboda","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; E-Boda Supreme X80 Dual Core Build\/ICS.g12refM806A1YBD.20120925) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Eboda","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-boda essential smile Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Fly","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Fly IQ440; Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Fly","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; FLY IQ256 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Fujitsu","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ja-jp; F-10D Build\/V21R48A) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"V21R48A","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Fujitsu","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; M532 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"IML74K","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Galapad","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-tw; G1 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Webkit":"534.30","Safari":"4.0","Build":"JRO03C"}},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; el-gr; GOCLEVER TAB A103 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; zh-tw; A7GOCLEVER Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; GOCLEVER TAB A104 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; cs-cz; GOCLEVER TAB A93.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; sk-sk; GOCLEVER TAB A971 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; lv-lv; GOCLEVER TAB A972BK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; GOCLEVER TAB A104.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"GoClever","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-pt; GOCLEVER TAB T76 Build\/MID) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.40 Mobile Safari\/537.31 OPR\/14.0.1074.54070","mobile":true,"tablet":false,"version":{"Android":"4.2.2","Build":"JDQ39","Webkit":"537.31","Opera":"14.0.1074.54070"}},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; Nexus 4 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Mobile Safari\/537.31","mobile":true,"tablet":false,"version":{"Android":"4.2.2","Chrome":"26.0.1410.58"}},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; Nexus 7 Build\/JRO03D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.2; Nexus 7 Build\/JOP40C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; Nexus 7 Build\/JZ054K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.1.2","Chrome":"18.0.1025.166"}},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; cs-cz; Nexus S Build\/JZO54K; CyanogenMod-10.0.0) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Google","user_agent":"Mozilla\/5.0 (Linux; Android 4.3; Nexus 10 Build\/JWR66Y) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"GU","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; TX-A1301 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"IMM76D","Webkit":"534.30","Safari":"4.0"}},{"vendor":"GU","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; da-dk; Q702 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"IML74K","Webkit":"534.30","Safari":"4.0"}},{"vendor":"HCL","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"HCL","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"HCL","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; Connect-3G-2.0 Build\/HCL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"HCL","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; pt-br; X1 Build\/HCL ME Tablet X1) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"HP","user_agent":"Mozilla\/5.0 (hp-tablet; Linux; hpwOS\/3.0.5; U; en-GB) AppleWebKit\/534.6 (KHTML, like Gecko) wOSBrowser\/234.83 Safari\/534.6 TouchPad\/1.0","mobile":true,"tablet":true},{"vendor":"HP","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; HP Slate 7 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"HP","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; HP Slate 7 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (X11; Linux x86_64; Z520m; en-ca) AppleWebKit\/534.24 (KHTML, like Gecko) Chrome\/11.0.696.34 Safari\/534.24","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"HTC_Touch_HD_T8282 Mozilla\/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 1.5; en-us; ADR6200 Build\/CUPCAKE) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1; xx-xx; Desire_A8181 Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; de-de; HTC Desire 1.19.161.5 Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; en-gb; HTC Desire Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; fr-fr; HTC Desire Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; en-dk; Desire_A8181 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; xx-xx; 001HT Build\/FRF91) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; xx-xx; HTCA8180\/1.0 Android\/2.2 release\/06.23.2010 Browser\/WAP 2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.2; de-at; HTC Desire Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.2; en-sk; Desire_A8181 Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3; xx-xx; HTC\/DesireS\/1.07.163.1 Build\/GRH78C) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-lv; HTC_DesireZ_A7272 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; ADR6300 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; en-gb; HTC\/DesireS\/2.10.161.3 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; HTC_DesireS_S510e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; en-us; Inspire 4G Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; de-de; HTC Explorer A310e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; en-gb; HTC_ChaCha_A810e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; nl-nl; HTC_DesireHD_A9191 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; HTC Desire S Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; HTC Desire Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; de-de; HTC_DesireHD Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ua; HTC_WildfireS_A510e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; en-us; HTC Vision Build\/GRI40; ILWT-CM7) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; HTC_GOF_U\/1.05.161.1 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; hu-hu; HTC Sensation Z710e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; pl-pl; EVO3D_X515m Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; HTC_One_S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; HTC_One_V Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC_A320e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; zh-tw; HTC Desire V Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; PG86100 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-nl; SensationXE_Beats_Z715e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ADR6425LVW 4G Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; HTC One V Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; cs-ee; Sensation_Z710e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; HTC Evo 4G Build\/MIUI) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; Desire HD Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-my; HTC_One_X Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; IncredibleS_S710e Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_Desire_S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; HTC One X Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; HTC Butterfly Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; EVO Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; HTCSensation Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; TITAN X310e)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T8788)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC 7 Mozart T8698; QSD8x50)","mobile":true,"tablet":false,"version":{"IE":"9.0","Windows Phone OS":"7.5","Trident":"5.0"},"model":"7 Mozart T8698"},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 HTC MOZART)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mondrian T8788)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart T8698)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart; Orange)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Pro T7576)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Pro)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Schubert T9292)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Surround)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Trophy T8686)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Trophy)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Eternity)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Gold)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD2 LEO)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD2)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD7 T9292)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD7)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; iPad 3)","mobile":true,"tablet":true},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; LEO)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mazaa)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mondrian)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mozart T8698)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mozart)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; mwp6985)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PC40100)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PC40200)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PD67100)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PI39100)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PI86100)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar 4G)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 1.08.164.02)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 2.05.164.01)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 2.05.168.02)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar; Orange)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schuber)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schubert T9292)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schubert)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Spark)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Surround)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T7575)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T8697)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T9295)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T9296)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Titan)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Torphy T8686)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; X310e)","mobile":true,"tablet":false},{"vendor":"HTC","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC_blocked; T8788)","mobile":true,"tablet":false,"version":{"IE":"9.0","Windows Phone OS":"7.5","Trident":"5.0"},"model":"T8788"},{"vendor":"Hudl","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; Hudl HT7S3 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.82 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; bg-bg; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1; en-us; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; lt-lt; U8660 Build\/HuaweiU8660) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; ru-ru; HUAWEI-U8850 Build\/HuaweiU8850) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; pl-pl; MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; nl-nl; HUAWEI MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"HUAWEI_T8951_TD\/1.0 Android\/4.0.4 (Linux; U; Android 4.0.4; zh-cn) Release\/05.31.2012 Browser\/WAP2.0 (AppleWebKit\/534.30) Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; ar-eg; MediaPad 7 Youth Build\/HuaweiMediaPad) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-cn; HW-HUAWEI_C8815\/C8815V100R001C541B135; 540*960; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_C8813D\/C8813DV100R001C92B172; 480*854; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Huwaei","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_Y300C\/Y300CV100R001C92B168; 480*800; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"iJoy","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; Tablet Planet II-v3 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Intenso","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1.;de-de; INM8002KP Build\/JR003H) AppleWebKit\/534.30 (KHTML, like Gecko)Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1.","Webkit":"534.30","Safari":"4.0"}},{"vendor":"IRU","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; M702pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"JXD","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; F3000 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Karbonn","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; ST10 Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Kobo","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 (Kobo Touch)","mobile":true,"tablet":true,"version":{"Android":"2.0","Webkit":"533.1","Safari":"4.0"}},{"vendor":"Lenovo","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Lenovo","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Lenovo","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; ThinkPad Tablet Build\/ThinkPadTablet_A400_03) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; en-us; LG-P509 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.2; pt-br; LG-P350f Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LG-P500 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; LS670 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; LG-E510 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MMS\/LG-Android-MMS-V1.0\/1.2","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; VS910 4G Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-P700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build\/IML74K) AppleWebkit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-F160S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; LG-E610v\/V10f Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; LG-E612 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; LG-F180K Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; LG-V500 Build\/JDQ39B) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG E-900)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-C900k)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900; Orange)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-E900h)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; LG; LG-Optimus 7)","mobile":true,"tablet":false},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.0.1; ja-jp; L-06C Build\/HRI66) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"LG","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.0; en-us; LG-V900 Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Megafon","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; MegaFon V9 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Megafon","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; MT7A Build\/JRO03C) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31","mobile":true,"tablet":true},{"vendor":"MediaTek","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; MT8377 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30\/4.05d.1002.m7","mobile":true,"tablet":true},{"vendor":"Micromax","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; Micromax A110 Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22","mobile":true,"tablet":false,"version":{"Android":"4.1.1","Build":"JRO03C","Webkit":"537.22","Chrome":"25.0.1364.169"}},{"vendor":"Micromax","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; Micromax P250(Funbook) Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Webkit":"534.30","Android":"4.0","Build":"IMM76D","Safari":"4.0"}},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)","mobile":true,"tablet":true,"version":{"IE":"10.0","Windows NT":"6.2","Trident":"6.0"}},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0)","mobile":true,"tablet":true},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)","mobile":true,"tablet":true},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; ARMBJS)","mobile":true,"tablet":true},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MASMJS)","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:25.0) Gecko\/20130626 Firefox\/25.0","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:22.0) Gecko\/20100101 Firefox\/22.0","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MDDCJS)","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MDDCJS)","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.52 Safari\/537.36 OPR\/15.0.1147.130","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.116 Safari\/537.36","mobile":false,"tablet":false},{"vendor":"Microsoft","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MDDCJS; WebView\/1.0)","mobile":false,"tablet":false},{"vendor":"Modecom","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; pl-pl; FreeTAB 1014 IPS X4+ Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Motorola","user_agent":"MOT-W510\/08.11.05R MIB\/BER2.2 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 EGE\/1.0 UP.Link\/6.3.0.0.0","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.2; zh-cn; ME722 Build\/MLS2GC_2.6.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; DROIDX Build\/4.5.1_57_DX8-51) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; en-us; MB855 Build\/4.5.1A-1_SUN-254_13) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; es-us; MB526 Build\/4.5.2-51_DFL-50) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-ca; MB860 Build\/4.5.2A-51_OLL-17.8) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; en-us; MOT-XT535 Build\/V1.540) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; ko-kr; A853 Build\/SHOLS_U2_05.26.3; CyanogenMod-7.1.2) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.0; en-us; Xoom Build\/HRI39) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.1; en-us; Xoom Build\/HMJ25) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; DROID RAZR 4G Build\/6.7.2-180_DHD-16_M4-31) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; Xoom Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; XT687 Build\/V2.27D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false,"version":{"Android":"4.0.4","Webkit":"534.30","Safari":"4.0"},"model":"XT687"},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; MOT-XT910 Build\/6.7.2-180_SPU-19-TA-11.6) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT910 Build\/9.8.2O-124_SPUL-17) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT915 Build\/2_32A_2031) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT919 Build\/2_290_2017) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.64 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT925 Build\/9.8.2Q-50-XT925_VQLM-20) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT907 Build\/9.8.1Q-66) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; XT901 Build\/9.8.2Q-50_SLS-13) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Motorola","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; DROID BIONIC Build\/9.8.2O-72_VZW-22) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Nabi","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NABI-A Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"NEC","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ja-jp; N-08D Build\/A5001911) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"NEC","user_agent":"Mozilla\/5.0 (Linux; U; Android AAA; BBB; N-06D Build\/CCC) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Nook","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NOOK BNRV200 Build\/ERD79 1.4.3) Apple WebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true,"version":{"Android":"2.2.1","Webkit":"533.1","Safari":"4.0"}},{"vendor":"Nook","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; NOOK BNTV400 Build\/ICS) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"ICS","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Nook","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; BNTV600 Build\/IMM76L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36 Hughes-PFB\/CID5391275.AID1376709964","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"IMM76L","Webkit":"537.36","Chrome":"28.0.1500.94"}},{"vendor":"Nokia","user_agent":"Nokia200\/2.0 (12.04) Profile\/MIDP-2.1 Configuration\/CLDC-1.1 UCWEB\/2.0 (Java; U; MIDP-2.0; en-US; nokia200) U2\/1.0.0 UCBrowser\/8.9.0.251 U2\/1.0.0 Mobile UNTRUSTED\/1.0","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Nokia6303iclassic\/5.0 (06.61) Profile\/MIDP-2.1 Configuration\/CLDC-1.1 Mozilla\/5.0 AppleWebKit\/420+ (KHTML, like Gecko) Safari\/420+","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"nokian73-1\/UC Browser7.8.0.95\/69\/400 UNTRUSTED\/1.0","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Nokia2760\/2.0 (06.82) Profile\/MIDP-2.1 Configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Nokia3650\/1.0 SymbianOS\/6.1 Series60\/1.2 Profile\/MIDP-1.0 Configuration\/CLDC-1.0","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"NokiaN70-1\/5.0737.3.0.1 Series60\/2.8 Profile\/MIDP-2.0 Configuration\/CLDC-1.1\/UC Browser7.8.0.95\/27\/352","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (S60V3; U; ru; NokiaN73) AppleWebKit\/530.13 (KHTML, like Gecko) UCBrowser\/8.6.0.199\/28\/444\/UCWEB Mobile","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (S60V3; U; ru; NokiaC5-00.2)\/UC Browser8.5.0.183\/28\/444\/UCWEB Mobile","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (S60V3; U; ru; NokiaC5-00.2) AppleWebKit\/530.13 (KHTML, like Gecko) UCBrowser\/8.7.0.218\/28\/352\/UCWEB Mobile","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Series40; NokiaC3-00\/08.63; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) Gecko\/20100401 S40OviBrowser\/2.2.0.0.33","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Opera\/9.80 (Series 60; Opera Mini\/7.0.31380\/28.2725; U; es) Presto\/2.8.119 Version\/11.10","mobile":true,"tablet":false,"version":{"Opera Mini":"7.0.31380","Presto":"2.8.119"}},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.2 NokiaC7-00\/025.007; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.37 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.2 NokiaX7-00\/022.014; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.37 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaE6-00\/111.140.0058; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaC6-01\/111.040.1511; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaC6-01; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia700\/111.030.0609; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia700\/111.020.0308; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.1.14 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaN8-00\/111.040.1511; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia701\/111.030.0609; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120c\/3.83; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120ci\/7.02; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120c\/7.10; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE66-1\/510.21.009; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE71-1\/110.07.127; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaN95-3\/20.2.011 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE51-1\/200.34.36; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE63-1\/500.21.009; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaN82\/10.0.046; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE52-1\/052.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.2","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE52-1\/@version@; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.26 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00\/031.022; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.3.1","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00.2\/081.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.32 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; U; Series60\/3.2 NokiaN79-1\/32.001; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; U; Series60\/3.2 Nokia6220c-1\/06.101; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00.2\/071.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.26 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE72-1\/081.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.32 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00\/061.005; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.2 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaX6-00\/40.0.002; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gb","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5800d-1\/60.0.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaC5-03\/12.0.023; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.9 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5228\/40.1.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.7.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5230\/51.0.002; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5530c-2\/32.0.007; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.9 3gpp-gba","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaN97-1\/21.0.045; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) BrowserNG\/7.1.4","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaN97-4\/30.0.004; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.28 3gpp-gba","mobile":true,"tablet":false,"version":{"Symbian":"9.4","Webkit":"533.4","NokiaBrowser":"7.3.1.28"},"model":"NokiaN97-4"},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 7 Mozart T8698)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; 710)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800C)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800C; Orange)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 900)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; HD7 T9292)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; LG E-900)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 610)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; Orange)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; T-Mobile)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; Vodafone)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800) UP.Link\/5.1.2.6","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; Orange)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; SFR)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; T-Mobile)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; vodafone)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Lumia 800c)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 900)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Lumia 920)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 920)","mobile":true,"tablet":false,"version":{"IE":"10.0","Windows Phone OS":"8.0","Trident":"6.0"},"model":"Lumia 920"},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; lumia800)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 610)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 710)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 800)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 800C)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 900)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Nokia)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; SGH-i917)","mobile":true,"tablet":false},{"vendor":"Nokia","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; TITAN X310e)","mobile":true,"tablet":false,"version":{"Windows Phone OS":"7.5","Trident":"5.0"},"model":"TITAN X310e"},{"vendor":"OverMax","user_agent":"OV-SteelCore(B) Mozilla\/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3","mobile":true,"tablet":true},{"vendor":"OverMax","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-SteelCore Build\/ICS.g08refem611.20121010) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"YONESTablet","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; BC1077 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Pantech","user_agent":"PANTECH-C790\/JAUS08312009 Browser\/Obigo\/Q05A Profile\/MIDP-2.0 Configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Pantech","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; ko-kr; SKY IM-A600S Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Pantech","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; ADR8995 4G Build\/GRI40) AppleWebKit\/533.1 (KHTML like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Pantech","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; PantechP4100 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Philips","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; W732 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"PointOfView","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; POV_TAB-PROTAB30-IPS10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Prestigio","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; PMP5297C_QUAD Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Prestigio","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; sk-sk; PMP7100D3G Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"IMM76D","Webkit":"534.30","Safari":"4.0"},"model":"PMP7100D3G"},{"vendor":"Prestigio","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; sk-sk; PMP7280C3G Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 MobilSafari\/534.30","mobile":true,"tablet":true},{"vendor":"PROSCAN","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; PLT8088 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Build":"JRO03H","Webkit":"534.30","Safari":"4.0"}},{"vendor":"PyleAudio","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; PTBL92BC Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Mobile Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.0.4","Build":"IMM76D","Webkit":"537.36","Chrome":"31.0.1650.59"}},{"vendor":"RockChip","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; hu-hu; RK2818, Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"RockChip","user_agent":"Mozilla\/5.0 (Linux; U; Android Android 2.1-RK2818-1.0.0; zh-cn; MD701 Build\/ECLAIR) AppleWebKit\/530.17 (KHTML like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":true},{"vendor":"RossMoor","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.1; ru-ru; RM-790 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"QMobile","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; A2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"MQQBrowser\/4.0\/Mozilla\/5.0 (Linux; U; Android 3.2; zh-cn; GT-P6800 Build\/HTJ85B) AppleWebKit\/533.1 (KHTML, like Gecko) Mobile Safari\/533.1","mobile":true,"tablet":true,"version":{"MQQBrowser":"4.0"}},{"vendor":"Samsung","user_agent":"SAMSUNG-SGH-P250-ORANGE\/P250BVHH8 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 UP.Browser\/6.2.3.3.c.1.101 (GUI) MMP\/2.0","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"SAMSUNG-GT-B2710\/B271MCXKF1 SHP\/VPP\/R5 Dolfin\/2.0 QTV\/5.3 SMM-MMS\/1.2.0 profile\/MIDP-2.1 configuration\/CLDC-1.1 OPN-B","mobile":true,"tablet":false,"version":{"Dolfin":"2.0"}},{"vendor":"Samsung","user_agent":"SAMSUNG-SGH-D900i\/1.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 UP.Browser\/6.2.3.3.c.1.101 (GUI) MMP\/2.0","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"SAMSUNG-GT-S5233T\/S5233TXEJE3 SHP\/VPP\/R5 Jasmine\/0.8 Qtv5.3 SMM-MMS\/1.2.0 profile\/MIDP-2.1 configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (SAMSUNG; SAMSUNG-GT-S5380D\/S5380FXXKL3; U; Bada\/2.0; ru-ru) AppleWebKit\/534.20 (KHTML, like Gecko) Dolfin\/3.0 Mobile HVGA SMM-MMS\/1.2.0 OPN-B","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"SAMSUNG-GT-C3312\/1.0 NetFront\/4.2 Profile\/MIDP-2.0 Configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 1.5; de-de; Galaxy Build\/CUPCAKE) AppleWebKit\/528.5 (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"SAMSUNG-GT-S3650\/S3650XEII3 SHP\/VPP\/R5 Jasmine\/1.0 Nextreaming SMM-MMS\/1.2.0 profile\/MIDP-2.1 configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"JUC (Linux; U; 2.3.6; zh-cn; GT-S5360; 240*320) UCWEB7.9.0.94\/140\/352","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (SAMSUNG; SAMSUNG-GT-S5250\/S5250XEKJ3; U; Bada\/1.0; ru-ru) AppleWebKit\/533.1 (KHTML, like Gecko) Dolfin\/2.0 Mobile WQVGA SMM-MMS\/1.2.0 NexPlayer\/3.0 profile\/MIDP-2.1 configuration\/CLDC-1.1 OPN-B","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident\/3.1; IEMobile\/7.0; SAMSUNG; SGH-i917)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (SAMSUNG; SAMSUNG-GT-S8530\/S8530XXJKA; U; Bada\/1.2; cs-cz) AppleWebKit\/533.1 (KHTML, like Gecko) Dolfin\/2.2 Mobile WVGA SMM-MMS\/1.2.0 OPN-B","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 1.6; ru-ru; Galaxy Build\/Donut) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; ru-ru; GT-I5500 Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; en-us; GALAXY_Tab Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; ja-jp; SC-01C Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; fr-fr; GT-I9000 Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2.1; zh-cn; SCH-i909 Build\/FROYO) UC AppleWebKit\/534.31 (KHTML, like Gecko) Mobile Safari\/534.31","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; ja-jp; SC-01C Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-gb; GT-P1000 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; el-gr; GT-I9001 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-ca; SGH-I896 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; es-us; GT-S5660L Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 MicroMessenger\/4.5.1.261","mobile":true,"tablet":false,"version":{"MicroMessenger":"4.5.1.261"}},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; GT-S5660 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; GT-S6102 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; pt-br; GT-S5367 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; fr-fr; GT-S5839i Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-gb; GT-S7500 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-gb; GT-S5830 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; es-us; GT-B5510L Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; pl-pl; GT-I9001-ORANGE\/I9001BVKPC Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; GT-I8150 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; nl-nl; GT-I9070 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-gb; GT-S5360 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; es-us; GT-S6102B Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; GT-S5830i Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; GT-I8160 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; GT-S6802 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; ru-ru; GT-S5830 Build\/GRWK74; LeWa_ROM_Cooper_12.09.21) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; GT-N7000 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.0.1; en-us; GT-P7100 Build\/HRI83) AppleWebkit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; he-il; GT-P7300 Build\/HTJ85B) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; en-gb; GT-P6200 Build\/HTJ85B) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; GT-I9100 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; GT-I9100G Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; GT-P5100 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build\/IML74K) AppleWebKit\/535.7 (KHTML, like Gecko) CrMo\/16.0.912.75 Mobile Safari\/535.7","mobile":true,"tablet":false,"version":{"Chrome":"16.0.912.75"}},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; SGH-T989 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false,"version":{"Chrome":"18.0.1025.166"}},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; GT-P5100 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; GT-I9300 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; SPH-D710 Build\/IMM76I) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-cn; GT-I9300 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; GT-I9300-ORANGE\/I9300BVBLG2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; th-th; GT-I9300T Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; GT-I9100 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us ; GT-I9100 Build\/IMM76D) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.4.1.204\/145\/355","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; GT-N7000 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; th-th; GT-P6800 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; SAMSUNG-SGH-I747 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; GT-P5110 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; GT-P5110 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-cn; SAMSUNG-GT-S7568_TD\/1.0 Android\/4.0.4 Release\/07.15.2012 Browser\/AppleWebKit534.30 Build\/IMM76D) ApplelWebkit\/534.30 (KHTML,like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false,"version":{"Android":"4.0.4"}},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; GT-P3100 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; tr-tr; GT-P3105 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-ca; GT-N8010 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; GT-S7562 Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; GT-N7100 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; GT-N7100 Build\/JZO54K) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.123 Mobile Safari\/537.22 OPR\/14.0.1025.52315","mobile":true,"tablet":false,"version":{"Build":"JZO54K","Webkit":"537.22","Opera":"14.0.1025.52315"}},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-hk; GT-N7105 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; GT-N8000 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; SGH-i747M Build\/JRO03L) AppleWebKit\/535.19(KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; Galaxy Nexus - 4.1.1 - with Google Apps - API 16 - 720x1280 Build\/JRO03S) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; GT-I8262 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; it-it; Galaxy Nexus Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; SGH-I777 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; GT-S7710 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; GT-I9082 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; SGH-T999L Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; GT-P5210 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, Like Gecko) Chrome\/27.0.1453.90 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG GT-I9200 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Version\/1.0 Chrome\/18.0.1025.308 Mobile Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; zh-cn; SCH-I959 Build\/JDQ39) AppleWebKit\/535.19 (KHTML, like Gecko) Version\/1.0 Chrome\/18.0.1025.308 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; nl-nl; SM-T310 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; Android 4.3; en-us; SAMSUNG SM-P600 Build\/JSS15J) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/1.5 Chrome\/28.0.1500.94 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; GT-N5100 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; CETUS)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; Focus I917 By TC)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; Focus i917)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; FOCUS S)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; GT-I8350)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; GT-i8700)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; GT-S7530)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; Hljchm's Wp)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; I917)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; OMNIA 7)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; OMNIA7 By MWP_HS)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; OMNIA7)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; OMNIA7; Orange)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SGH-i677)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SGH-i917)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SGH-i917.)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SGH-i917R)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SGH-i937)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG; SMG-917R)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG_blocked_blocked_blocked; OMNIA7; Orange)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SAMSUNG_blocked_blocked_blocked_blocked; OMNIA7; Orange)","mobile":true,"tablet":false},{"vendor":"Samsung","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; SUMSUNG; OMNIA 7)","mobile":true,"tablet":false},{"vendor":"simvalley","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; de-de; SP-80 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"SonyEricssonK800i\/R1AA Browser\/NetFront\/3.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; es-ar; SonyEricssonE15a Build\/2.0.1.A.0.47) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.1-update1; pt-br; SonyEricssonU20a Build\/2.1.1.A.0.6) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonX10i Build\/3.0.1.G.0.75) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; SonyEricssonST18i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; hr-hr; SonyEricssonST15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; sk-sk; SonyEricssonLT15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; th-th; SonyEricssonST27i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; SonyEricssonST25i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-br; Xperia Tablet S Build\/TID0092) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"TID0092","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; LT18i Build\/4.1.A.0.562) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; Sony Tablet S Build\/TISU0R0110) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Sony Tablet S Build\/TISU0143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; SonyEricssonLT18i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-ch; SonyEricssonSK17i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT26i Build\/6.1.A.2.45) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; LT22i Build\/6.1.B.0.544) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; SonyEricssonLT22i Build\/6.1.B.0.544) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.5.5) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.2.10) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; LT28h Build\/6.1.E.3.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; SGPT13 Build\/TJDS0170) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; ja-jp; SonySO-03E Build\/10.1.E.0.265) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.2","Build":"10.1.E.0.265","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.2; LT26w Build\/6.2.B.1.96) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Mobile Safari\/537.36","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; SGP321 Build\/10.3.1.A.0.33) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"10.3.1.A.0.33","Webkit":"537.31","Chrome":"26.0.1410.58"}},{"vendor":"Sony","user_agent":"SonyEricssonU5i\/R2CA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"SonyEricssonU5i\/R2AA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Mozilla\/4.0 (PDA; PalmOS\/sony\/model prmr\/Revision:1.1.54 (en)) NetFront\/3.0","mobile":true,"tablet":false},{"vendor":"Sony","user_agent":"Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00","mobile":false,"tablet":false},{"vendor":"Sony","user_agent":"Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11","mobile":false,"tablet":false},{"vendor":"Skk","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1; en-us; CYCLOPS Build\/F10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Storex","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; eZee_Tab903 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Build":"JRO03H","Webkit":"537.36"}},{"vendor":"Storex","user_agent":"Mozilla\/5.0 (Linux; Android 4.1.1; eZee'Tab785 Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Build":"JRO03C","Webkit":"537.36"}},{"vendor":"Storex","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; eZee'Tab971 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true,"version":{"Android":"4.0.3","Build":"IML74K","Webkit":"535.19"}},{"vendor":"Tecno","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; TECNO P9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Telstra","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.7; en-au; T-Hub2 Build\/TVA301TELBG3) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true},{"vendor":"texet","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; TM-7021 Build\/GB.m1ref.20120116) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true,"version":{"Android":"2.3.4","Webkit":"533.1","Safari":"4.0"},"model":"TM-7021"},{"vendor":"Tolino","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"JDQ39","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Tolino","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 8.9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"JDQ39","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Tolino","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.57 Safari\/537.36 OPR\/18.0.1290.67495","mobile":true,"tablet":true},{"vendor":"Tolino","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Toshiba","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; TOSHIBA; TSUNAGI)","mobile":true,"tablet":false},{"vendor":"Toshiba","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; it-it; TOSHIBA_FOLIO_AND_A Build\/TOSHIBA_FOLIO_AND_A) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":true,"version":{"Android":"2.2","Webkit":"533.1","Safari":"4.0"}},{"vendor":"Trekstor","user_agent":"Mozilla\/5.0 (Linux; Android 4.2.2; ST70408-1 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31","mobile":true,"tablet":true,"version":{"Android":"4.2.2","Build":"JDQ39","Webkit":"537.31","Chrome":"26.0.1410.58"}},{"vendor":"Visture","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; V97 HD Build\/LR-97JC) Apple WebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Visture","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Visture V4 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Visture","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V4 HD Build\/Visture V4 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Visture","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; Visture V5 HD Build\/Visture V5 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Visture","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; VS-TOUCHPAD 9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; Versus Touchpad 9.7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; CnM-TOUCHPAD7 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 BMID\/E67A45B1AB","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; CnM TouchPad 7DC Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 TwonkyBeamBrowser\/3.3.5-95 (Android 4.1.1; rockchip CnM TouchPad 7DC Build\/meizhi_V2.80.wifi8723.20121225.b11c800)","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"OneBrowser\/3.5\/Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Versus","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; TOUCHTAB Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true,"version":{"Android":"4.1.1","Build":"JRO03H","Webkit":"534.30","Safari":"4.0"}},{"vendor":"Vodafone","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; hu-hu; SmartTab10-MSM8260-V02d-Dec022011-Vodafone-HU) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0","mobile":true,"tablet":true},{"vendor":"Vodafone","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; SmartTabII10 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19","mobile":true,"tablet":true},{"vendor":"Vodafone","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; SmartTAB 1002 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Vonino","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Sirius_Evo_QS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Vonino","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; Q8 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"ZTE","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.1;zh-cn; ZTE V987 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30;","mobile":true,"tablet":false},{"vendor":"ZTE","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.5; pt-pt; Blade Build\/tejosunhsine) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1","mobile":true,"tablet":false},{"vendor":"ZTE","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; N880e_Dawoer_Fulllock; China Telecom)","mobile":true,"tablet":false},{"vendor":"ZTE","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; V965W)","mobile":true,"tablet":false},{"vendor":"ZTE","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; Windows Phone - Internet 7; SFR)","mobile":true,"tablet":false},{"vendor":"Zync","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us ; Z909 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.4.1.204\/145\/444","mobile":true,"tablet":true},{"vendor":"Console","user_agent":"Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/534.52 (KHTML, like Gecko) NX\/{Version No} NintendoBrowser\/{Version No}.US","mobile":false,"tablet":false},{"vendor":"Console","user_agent":"Mozilla\/5.0 (PLAYSTATION 3 4.21) AppleWebKit\/531.22.8 (KHTML, like Gecko)","mobile":false,"tablet":false},{"vendor":"Console","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident\/5.0; Xbox)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Ubuntu Chromium\/32.0.1700.102 Chrome\/32.0.1700.102 Safari\/537.36","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko\/20100101 Firefox\/24.0","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko\/20100101 Firefox\/18.0 AlexaToolbar\/psPCtGhf-2.2","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:22.0) Gecko\/20100101 Firefox\/22.0","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (X11; Linux ppc; rv:17.0) Gecko\/20130626 Firefox\/17.0 Iceweasel\/17.0.7","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (X11; Linux) AppleWebKit\/535.22+ Midori\/0.4","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Macintosh; U; Intel Mac OS X; en-us) AppleWebKit\/535+ (KHTML, like Gecko) Version\/5.0 Safari\/535.20+ Midori\/0.4","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 5.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 5.2; WOW64; rv:21.0) Gecko\/20100101 Firefox\/21.0","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Opera\/9.80 (Windows NT 5.2; WOW64) Presto\/2.12.388 Version\/12.14","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko\/20100101 Firefox\/19.0","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (X11; FreeBSD amd64; rv:14.0) Gecko\/20100101 Firefox\/14.0.1","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Tablet PC 2.0; MASMJS)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MANMJS)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MASMJS)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; Touch; MASMJS)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Opera\/9.80 (Windows NT 6.2; WOW64; MRA 8.0 (build 5784)) Presto\/2.12.388 Version\/12.11","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident\/6.0)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.3; Trident\/7.0; rv 11.0) like Gecko","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Windows NT 6.3; WOW64; Trident\/7.0; Touch; rv:11.0) like Gecko","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/537.1+ (KHTML, like Gecko) Safari\/537.1+ HbbTV\/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"HbbTV\/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)","mobile":false,"tablet":false},{"vendor":"Other","user_agent":"Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11","mobile":false,"tablet":false},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; ALUMIUM10 Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36","mobile":true,"tablet":true},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2.1; en-us; JY-G3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":false},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; M758A Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; EVOTAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30","mobile":true,"tablet":true},{"vendor":"Generic","user_agent":"Java\/1.6.0_22","mobile":false,"tablet":false,"version":{"Java":"1.6.0_22"}},{"vendor":"Generic","user_agent":"Opera\/9.80 (Series 60; Opera Mini\/6.5.29260\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10","mobile":true,"tablet":false},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android; Opera Mini\/6.5.27452\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10","mobile":true,"tablet":false},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Windows NT 6.1; WOW64) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.60 Safari\/537.17 OPR\/14.0.1025.52315","mobile":false,"tablet":false},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (X11; CrOS armv7l 4920.83.0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.103 Safari\/537.36"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8H7 Safari\/6533.18.5"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-I9070 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android 2.3.7; Linux; Opera Mobi\/46154) Presto\/2.11.355 Version\/12.10"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; it-it; DATAM819HD_C Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; SGPT12 Build\/TID0142) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; cm_tenderloin Build\/IMM76L; CyanogenMod-9) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; A210 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (iPad; CPU OS 6_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B141 Safari\/8536.25"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; en-gb; GT-I8150 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Mercury\/7.2 Mobile\/10A523 Safari\/8536.25"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android 2.3.7; Linux; Opera Tablet\/46154) Presto\/2.11.355 Version\/12.10"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; sdk Build\/MASTER) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; GT-P7510 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Opera\/9.80 (X11; Linux zbov) Presto\/2.11.355 Version\/12.10"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (iPhone; U; CPU OS 4_2_1 like Mac OS X) AppleWebKit\/532.9 (KHTML, like Gecko) Version\/5.0.3 Mobile\/8B5097d Safari\/6531.22.7"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; SGPT12 Build\/TID0142) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7498.US"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.0.6_b1; ru-ru Build\/ECLAIR) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.4; z1000 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; Android 4.0.3; cm_tenderloin Build\/GWK74) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; Android for Techvision TV1T808 Board Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"},{"vendor":"Generic","user_agent":"BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.56 Safari\/537.17"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.1; ru-ru; LG-V900 Build\/HMJ37) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; HTC; Windows Phone 8S by HTC)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (PLAYSTATION 3 4.11) AppleWebKit\/531.22.8 (KHTML, like Gecko)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2; ru-ru; V9S_V1.4) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; WebView\/1.0)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; Next7P12 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Generic","user_agent":"Opera\/9.80 (X11; Linux zbov) Presto\/2.11.355 Version\/12.10"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 2.3.6; es-es; SAMSUNG GT-S5830\/S5830BUKT2 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 3.2.1; en-gb;HTC_Flyer_P512 Build\/HTK75C) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; full Android on Microsoft Windows, pad, pc, n*books Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Android; Mobile; rv:18.0) Gecko\/18.0 Firefox\/18.0"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/535.12 (KHTML, like Gecko) Maxthon\/3.0 Chrome\/18.0.966.0 Safari\/535.12"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Windows NT 5.1; U; Edition Yx; ru) Presto\/2.10.289 Version\/12.02"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Generic","user_agent":"Mozilla\/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)"},{"vendor":"Generic","user_agent":"PalmCentro\/v0001 Mozilla\/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource\/Palm-D061; Blazer\/4.5) 16;320x320"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Microsoft; XDeviceEmulator)"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; MAL; N880E; China Telecom)"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Series 60; Opera Mini\/7.0.29482\/28.2859; U; ru) Presto\/2.8.119 Version\/11.10"},{"vendor":"Generic","user_agent":"Opera\/9.80 (S60; SymbOS; Opera Mobi\/SYB-1202242143; U; en-GB) Presto\/2.10.254 Version\/12.00"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; 97D Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android; Opera Mini\/7.0.29952\/28.2647; U; ru) Presto\/2.8.119 Version\/11.10"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android; Opera Mini\/6.1.25375\/28.2555; U; en) Presto\/2.8.119 Version\/11.10"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Mac OS X; Opera Tablet\/35779; U; en) Presto\/2.10.254 Version\/12.00"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Android; Tablet; rv:10.0.4) Gecko\/10.0.4 Firefox\/10.0.4 Fennec\/10.0.4"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Android; Tablet; rv:18.0) Gecko\/18.0 Firefox\/18.0"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Linux armv7l; Maemo; Opera Mobi\/14; U; en) Presto\/2.9.201 Version\/11.50"},{"vendor":"Generic","user_agent":"Opera\/9.80 (Android 2.2.1; Linux; Opera Mobi\/ADR-1207201819; U; en) Presto\/2.10.254 Version\/12.00"},{"vendor":"Generic","user_agent":"Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; sdk Build\/JRO03E) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"},{"vendor":"Bot","user_agent":"Mozilla\/5.0 (compatible; Googlebot\/2.1; +http:\/\/www.google.com\/bot.html)","mobile":false,"tablet":false},{"vendor":"Bot","user_agent":"grub-client-1.5.3; (grub-client-1.5.3; Crawl your own stuff with http:\/\/grub.org)","mobile":false,"tablet":false},{"vendor":"Bot","user_agent":"Googlebot-Image\/1.0","mobile":false,"tablet":false},{"vendor":"Bot","user_agent":"Python-urllib\/2.5","mobile":false,"tablet":false},{"vendor":"Bot","user_agent":"facebookexternalhit\/1.0 (+http:\/\/www.facebook.com\/externalhit_uatext.php)","mobile":false,"tablet":false}]}
+{
+    "hash": "76b8ffe98c51c18a2db3189c32f11ee1bec17567",
+    "user_agents": [
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; A100 Build\/HTK55D) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; A110 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "IML74K"
+            },
+            "model": "A200"
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; A701 Build\/JRO03H) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-710 Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A1-810 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; nl-nl; A1-810 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Acer",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; A3-A10 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "537.36",
+                "Chrome": "32.0.1700.99"
+            }
+        },
+        {
+            "vendor": "AdvanDigital",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; E1C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AdvanDigital",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; id-id; T3C Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; Ainol Novo8 Advanced Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Novo10 Hero Build\/20121115) AppleWebKit\/535.19 (KHTML like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Ainol",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; es-es; novo9-Spark Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AllFine",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; FINE7 GENIUS Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "3.2.1",
+                "Webkit": "534.13",
+                "Safari": "4.0"
+            },
+            "model": "Transformer TF101"
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; asus_laptop Build\/IMM76L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; PadFone 2 Build\/JRO03L) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03L",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME301T Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.1",
+                "Build": "JOP40D"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.1; ME173X Build\/JOP40D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.1",
+                "Build": "JOP40D"
+            }
+        },
+        {
+            "vendor": "ASUS",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; TF300T Build\/JDQ39E) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39E"
+            }
+        },
+        {
+            "vendor": "Alcatel",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-in; MB525 Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Alcatel",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; it-it; ALCATEL ONE TOUCH 918D Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "2.3.5",
+                "Webkit": "533.1",
+                "Safari": "4.0",
+                "Build": "GRJ90"
+            },
+            "model": "ONE TOUCH 918D"
+        },
+        {
+            "vendor": "Alcatel",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; ALCATEL ONE TOUCH 991 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "2.3.6",
+                "Webkit": "533.1",
+                "Safari": "4.0",
+                "Build": "GRJ90"
+            },
+            "model": "ONE TOUCH 991"
+        },
+        {
+            "vendor": "Alcatel",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; ALCATEL ONE TOUCH 993D Build\/ICECREAM) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.0.4",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "ICECREAM"
+            },
+            "model": "ONE TOUCH 993D"
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; ALLVIEW P5 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us ; ALLVIEW SPEEDI Build\/IMM76D) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.5.3.246\/145\/355",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; AllviewCity Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Allview",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ALLVIEWSPEED Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Silk\/3.4 Mobile Safari\/535.19 Silk-Accelerated=true",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; en-US) AppleWebKit\/528.5+ (KHTML, like Gecko, Safari\/528.5+) Version\/4.0 Kindle\/3.0 (screen 600x800; rotate)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Webkit": "528.5+",
+                "Kindle": "3.0",
+                "Safari": "4.0"
+            },
+            "model": "Kindle"
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; KFOTE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Amazon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; WFJWAE Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Apple",
+            "user_agent": "iTunes-AppleTV\/4.1",
+            "tv": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Qilive 97R Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.92 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Archos 50 Platinum Build\/JZO54K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ARCHOS 80G9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Archos",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; fr-fr; A101IT Build\/FROYO) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "AudioSonic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-au; T-17B Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9300; en) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Webkit": "534.8+",
+                "BlackBerry": "6.0.0.546"
+            },
+            "model": "BlackBerry 9300"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9360; en-US) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.400 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; he) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.723 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9700; en-US) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.448 Mobile Safari\/534.8",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9790; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.714 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Webkit": "534.11+",
+                "BlackBerry": "7.1.0.714"
+            },
+            "model": "BlackBerry 9790"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Opera\/9.80 (BlackBerry; Opera Mini\/7.0.29990\/28.2504; U; en) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9981; en-GB) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.342 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9800; en-GB) AppleWebKit\/534.8+ (KHTML, like Gecko) Version\/6.0.0.546 Mobile Safari\/534.8+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9780; es) AppleWebKit\/534.8  (KHTML, like Gecko) Version\/6.0.0.480 Mobile Safari\/534.8",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.0.0.583 Mobile Safari\/534.11",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9860; es) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.0.0.576 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9900; en-US) AppleWebKit\/534.11  (KHTML, like Gecko) Version\/7.1.0.523 Mobile Safari\/534.11",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.1067 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/603",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "BlackBerry8520\/5.0.0.1036 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/611",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "BlackBerry": "5.0.0.1036",
+                "VendorID": "611"
+            },
+            "model": "BlackBerry8520"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BlackBerry; U; BlackBerry 9220; en) AppleWebKit\/534.11+ (KHTML, like Gecko) Version\/7.1.0.337 Mobile Safari\/534.11+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit\/536.2+ (KHTML, like Gecko) Version\/7.2.1.0 Safari\/536.2+",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.1+ (KHTML, like Gecko) Version\/10.0.0.1337 Mobile Safari\/537.1+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) AppleWebKit\/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (BB10; Touch) \/537.10+ (KHTML, like Gecko) Version\/10.0.9.2372 Mobile Safari\/537.10+",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "BlackBerry": "10.0.9.2372"
+            }
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; Transformer TF101 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "3.2.1",
+                "Webkit": "534.13",
+                "Safari": "4.0"
+            },
+            "model": "Transformer TF101"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; de-de; A200 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A200"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A500 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A500"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; A501 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "A501"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Transformer Build\/JRO03L) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "Transformer"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ASUS Transformer Pad TF300T Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "Transformer Pad TF300T"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; Transformer Build\/JZO54K; CyanogenMod-10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "JZO54K"
+            },
+            "model": "Transformer"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; B1-A71 Build\/JZO54K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Webkit": "535.19",
+                "Chrome": "18.0.1025.166"
+            },
+            "model": "B1-A71"
+        },
+        {
+            "vendor": "BlackBerry",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Acer; Allegro)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Windows Phone OS": "7.5",
+                "Trident": "5.0",
+                "IE": "9.0"
+            },
+            "model": "Allegro"
+        },
+        {
+            "vendor": "Broncho",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Livingstone 2 Build\/1.1.7 20121018-10:33) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison Build\/1.1.10-1015 20121230-18:00) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Maxwell Lite Build\/v1.0.0.ICS.maxwell.20120920) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "bq",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; zh-tw; bq Maxwell Plus Build\/1.0.0 20120913-10:39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Casio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; C771 Build\/C771M120) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ChangJia",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pt-br; TPC97113 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ChangJia",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; TPC7102 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-us; MID7010 Build\/FRF85B) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID7048 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Coby",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; MID8042 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Concorde",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde Tab T10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Concorde",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde tab PLAY Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Cresta",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; nl-nl; CRESTA.CTP888 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Cube",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; CUBE U9GT 2 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Danew",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Dslide 700 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "Dslide 700"
+        },
+        {
+            "vendor": "DanyTech",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Genius Tab Q4 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.6; en-gb; Dell Streak Build\/Donut AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/ 525.20.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; hd-us; Dell Venue Build\/GWK74; CyanogenMod-7.2.0) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Dell",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; DELL; Venue Pro)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "DPS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; DPS Dream 9 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ECS",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; TM105A Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "534.30"
+            }
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme Dual Core X190 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Essential A160 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; E-Boda Supreme X80 Dual Core Build\/ICS.g12refM806A1YBD.20120925) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Eboda",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ro-ro; E-boda essential smile Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Fly",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ru-ru; Fly IQ440; Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Fly",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; ru-ru; FLY IQ256 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Fujitsu",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ja-jp; F-10D Build\/V21R48A) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "V21R48A",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Fujitsu",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; M532 Build\/IML74K) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Galapad",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-tw; G1 Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Webkit": "534.30",
+                "Safari": "4.0",
+                "Build": "JRO03C"
+            }
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; el-gr; GOCLEVER TAB A103 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; zh-tw; A7GOCLEVER Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; GOCLEVER TAB A104 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; cs-cz; GOCLEVER TAB A93.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; sk-sk; GOCLEVER TAB A971 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; lv-lv; GOCLEVER TAB A972BK Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; GOCLEVER TAB A104.2 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "GoClever",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-pt; GOCLEVER TAB T76 Build\/MID) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (X11; U; Linux i686; en-US) AppleWebKit\/533.4 (KHTML, like Gecko) Chrome\/5.0.375.127 Large Screen Safari\/533.4 GoogleTV\/ 162671",
+            "tv": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "Mozilla\/5.0 (X11; U: Linux i686; en-US) AppleWebKit\/533.4 (KHTML, like Gecko) Chrome\/5.0.375.127 Large Screen Safari\/533.4 GoogleTV\/b39389",
+            "tv": true
+        },
+        {
+            "vendor": "Google",
+            "user_agent": "CrKey",
+            "tv": true
+        },
+        {
+            "vendor": "GU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; TX-A1301 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "GU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; da-dk; Q702 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; U1 Build\/HCL ME Tablet U1) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; Connect-3G-2.0 Build\/HCL) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HCL",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; pt-br; X1 Build\/HCL ME Tablet X1) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (hp-tablet; Linux; hpwOS\/3.0.5; U; en-GB) AppleWebKit\/534.6 (KHTML, like Gecko) wOSBrowser\/234.83 Safari\/534.6 TouchPad\/1.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; HP Slate 7 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HP",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; HP Slate 7 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (X11; Linux x86_64; Z520m; en-ca) AppleWebKit\/534.24 (KHTML, like Gecko) Chrome\/11.0.696.34 Safari\/534.24",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "HTC_Touch_HD_T8282 Mozilla\/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 1.5; en-us; ADR6200 Build\/CUPCAKE) AppleWebKit\/528.5+ (KHTML, like Gecko) Version\/3.1.2 Mobile Safari\/525.20.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; xx-xx; Desire_A8181 Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; de-de; HTC Desire 1.19.161.5 Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; en-gb; HTC Desire Build\/ERE27) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; fr-fr; HTC Desire Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; en-dk; Desire_A8181 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; xx-xx; 001HT Build\/FRF91) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; xx-xx; HTCA8180\/1.0 Android\/2.2 release\/06.23.2010 Browser\/WAP 2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; de-at; HTC Desire Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.2; en-sk; Desire_A8181 Build\/FRG83G) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3; xx-xx; HTC\/DesireS\/1.07.163.1 Build\/GRH78C) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-lv; HTC_DesireZ_A7272 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; en-us; ADR6300 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; en-gb; HTC\/DesireS\/2.10.161.3 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; HTC_DesireS_S510e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; en-us; Inspire 4G Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; de-de; HTC Explorer A310e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; en-gb; HTC_ChaCha_A810e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; nl-nl; HTC_DesireHD_A9191 Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; HTC Desire S Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; HTC Desire Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; de-de; HTC_DesireHD Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ua; HTC_WildfireS_A510e Build\/GRJ90) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-us; HTC Vision Build\/GRI40; ILWT-CM7) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; HTC_GOF_U\/1.05.161.1 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; hu-hu; HTC Sensation Z710e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pl-pl; EVO3D_X515m Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; HTC_One_S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; ru-ru; HTC_One_V Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC_A320e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; zh-tw; HTC Desire V Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; PG86100 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-nl; SensationXE_Beats_Z715e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; ADR6425LVW 4G Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; HTC One V Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; cs-ee; Sensation_Z710e Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; HTC Evo 4G Build\/MIUI) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; Desire HD Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-my; HTC_One_X Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; it-it; IncredibleS_S710e Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_Desire_S Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; HTC One X Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; HTC Butterfly Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; EVO Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; HTCSensation Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; TITAN X310e)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T8788)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC 7 Mozart T8698; QSD8x50)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "IE": "9.0",
+                "Windows Phone OS": "7.5",
+                "Trident": "5.0"
+            },
+            "model": "7 Mozart T8698"
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 HTC MOZART)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mondrian T8788)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart T8698)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Mozart; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Pro T7576)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Pro)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Schubert T9292)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Surround)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Trophy T8686)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; 7 Trophy)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Eternity)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Gold)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD2 LEO)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD2)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD7 T9292)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; HD7)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; iPad 3)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; LEO)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mazaa)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mondrian)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mozart T8698)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Mozart)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; mwp6985)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PC40100)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PC40200)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PD67100)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PI39100)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; PI86100)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar 4G)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 1.08.164.02)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 2.05.164.01)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar C110e; 2.05.168.02)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Radar; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schuber)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schubert T9292)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Schubert)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Spark)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Surround)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T7575)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T8697)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T9295)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; T9296)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Titan)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; Torphy T8686)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC; X310e)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "HTC",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; HTC_blocked; T8788)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "IE": "9.0",
+                "Windows Phone OS": "7.5",
+                "Trident": "5.0"
+            },
+            "model": "T8788"
+        },
+        {
+            "vendor": "Hudl",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; Hudl HT7S3 Build\/JDQ39) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/30.0.1599.82 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; bg-bg; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1; en-us; Ideos S7 Build\/ERE27) AppleWebKit\/525.10+ (KHTML, like Gecko) Version\/3.0.4 Mobile Safari\/523.12.2",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; lt-lt; U8660 Build\/HuaweiU8660) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; ru-ru; HUAWEI-U8850 Build\/HuaweiU8850) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; pl-pl; MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; nl-nl; HUAWEI MediaPad Build\/HuaweiMediaPad) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "HUAWEI_T8951_TD\/1.0 Android\/4.0.4 (Linux; U; Android 4.0.4; zh-cn) Release\/05.31.2012 Browser\/WAP2.0 (AppleWebKit\/534.30) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ar-eg; MediaPad 7 Youth Build\/HuaweiMediaPad) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; zh-cn; HW-HUAWEI_C8815\/C8815V100R001C541B135; 540*960; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_C8813D\/C8813DV100R001C92B172; 480*854; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Huwaei",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_Y300C\/Y300CV100R001C92B168; 480*800; CTC\/2.0) AppleWebKit\/534.30 (KHTML, like Gecko) Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "iJoy",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; Tablet Planet II-v3 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Intenso",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1.;de-de; INM8002KP Build\/JR003H) AppleWebKit\/534.30 (KHTML, like Gecko)Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1.",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "IRU",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; M702pro Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "JXD",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; F3000 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Karbonn",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; ST10 Build\/JRO03C) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Kobo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.0; en-us;) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1 (Kobo Touch)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.0",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTab_A1107 Build\/MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; IdeaTab A2107A-H Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.90 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Lenovo",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; ThinkPad Tablet Build\/ThinkPadTablet_A400_03) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit\/531.2+ (KHTML, like Gecko) Safari\/531.2+ LG Browser\/4.1.4(+3D+SCREEN+TUNER; LGE; 42LW5700-SA; 04.02.28; 0x00000001;); LG NetCast.TV-2011",
+            "tv": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (DirectFB; U; Linux mips; en) AppleWebKit\/531.2+ (KHTML, like Gecko) Safari\/531.2+ LG Browser\/4.0.10(+SCREEN+TUNER; LGE; 42LE5500-SA; 04.02.02; 0x00000001;); LG NetCast.TV-2010",
+            "tv": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/537.1+ (KHTML, like Gecko) Safari\/537.1+ LG Browser\/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; GLOBAL-PLAT5; 03.07.01; 0x00000001;); LG NetCast.TV-2013\/03.17.01 (LG, GLOBAL-PLAT4, wired)",
+            "tv": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (DirectFB; Linux armv7l) AppleWebKit\/534.26+ (KHTML, like Gecko) Version\/5.0 Safari\/534.26+ HbbTV\/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)",
+            "tv": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/534.26+ (KHTML, like Gecko) Version\/5.0 Safari\/534.26+ HbbTV\/1.1.1 ( ;LG Electronics ;NetCast 3.0 ;1.0 ;1.0M ;)",
+            "tv": true
+        },
+        {
+            "vendor": "LG",
+            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/534.26+ (KHTML, like Gecko) Version\/5.0 Safari\/534.26+ HbbTV\/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)",
+            "tv": true
+        },
+        {
+            "vendor": "Megafon",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; ru-ru; MegaFon V9 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Megafon",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; MT7A Build\/JRO03C) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "MediaTek",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; MT8377 Build\/JRO03C) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30\/4.05d.1002.m7",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Micromax",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; Micromax A110 Build\/JRO03C) AppleWebKit\/537.22 (KHTML, like Gecko) Chrome\/25.0.1364.169 Mobile Safari\/537.22",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03C",
+                "Webkit": "537.22",
+                "Chrome": "25.0.1364.169"
+            }
+        },
+        {
+            "vendor": "Micromax",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0; xx-xx; Micromax P250(Funbook) Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Webkit": "534.30",
+                "Android": "4.0",
+                "Build": "IMM76D",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0)",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "IE": "10.0",
+                "Windows NT": "6.2",
+                "Trident": "6.0"
+            }
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; ARMBJS)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:25.0) Gecko\/20130626 Firefox\/25.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MDDCJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MDDCJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.52 Safari\/537.36 OPR\/15.0.1147.130",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.116 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Microsoft",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; MDDCJS; WebView\/1.0)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Modecom",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; pl-pl; FreeTAB 1014 IPS X4+ Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Motorola",
+            "user_agent": "Motorola KreaTV STB",
+            "tv": true
+        },
+        {
+            "vendor": "Nabi",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NABI-A Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "NEC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; ja-jp; N-08D Build\/A5001911) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "NEC",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android AAA; BBB; N-06D Build\/CCC) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; en-us; NOOK BNRV200 Build\/ERD79 1.4.3) Apple WebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.2.1",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; NOOK BNTV400 Build\/ICS) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "ICS",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Nook",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; BNTV600 Build\/IMM76L) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Safari\/537.36 Hughes-PFB\/CID5391275.AID1376709964",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76L",
+                "Webkit": "537.36",
+                "Chrome": "28.0.1500.94"
+            }
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Nokia200\/2.0 (12.04) Profile\/MIDP-2.1 Configuration\/CLDC-1.1 UCWEB\/2.0 (Java; U; MIDP-2.0; en-US; nokia200) U2\/1.0.0 UCBrowser\/8.9.0.251 U2\/1.0.0 Mobile UNTRUSTED\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Nokia6303iclassic\/5.0 (06.61) Profile\/MIDP-2.1 Configuration\/CLDC-1.1 Mozilla\/5.0 AppleWebKit\/420+ (KHTML, like Gecko) Safari\/420+",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "nokian73-1\/UC Browser7.8.0.95\/69\/400 UNTRUSTED\/1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Nokia2760\/2.0 (06.82) Profile\/MIDP-2.1 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Nokia3650\/1.0 SymbianOS\/6.1 Series60\/1.2 Profile\/MIDP-1.0 Configuration\/CLDC-1.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "NokiaN70-1\/5.0737.3.0.1 Series60\/2.8 Profile\/MIDP-2.0 Configuration\/CLDC-1.1\/UC Browser7.8.0.95\/27\/352",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (S60V3; U; ru; NokiaN73) AppleWebKit\/530.13 (KHTML, like Gecko) UCBrowser\/8.6.0.199\/28\/444\/UCWEB Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (S60V3; U; ru; NokiaC5-00.2)\/UC Browser8.5.0.183\/28\/444\/UCWEB Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (S60V3; U; ru; NokiaC5-00.2) AppleWebKit\/530.13 (KHTML, like Gecko) UCBrowser\/8.7.0.218\/28\/352\/UCWEB Mobile",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Series40; NokiaC3-00\/08.63; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) Gecko\/20100401 S40OviBrowser\/2.2.0.0.33",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/7.0.31380\/28.2725; U; es) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Opera Mini": "7.0.31380",
+                "Presto": "2.8.119"
+            }
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.2 NokiaC7-00\/025.007; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.37 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.2 NokiaX7-00\/022.014; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.37 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaE6-00\/111.140.0058; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaC6-01\/111.040.1511; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaC6-01; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia700\/111.030.0609; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia700\/111.020.0308; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.1.14 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 NokiaN8-00\/111.040.1511; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/535.1 (KHTML, like Gecko) NokiaBrowser\/8.3.1.4 Mobile Safari\/535.1 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (Symbian\/3; Series60\/5.3 Nokia701\/111.030.0609; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.4.2.6 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120c\/3.83; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120ci\/7.02; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 Nokia6120c\/7.10; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE66-1\/510.21.009; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE71-1\/110.07.127; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaN95-3\/20.2.011 Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE51-1\/200.34.36; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaE63-1\/500.21.009; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.2; U; Series60\/3.1 NokiaN82\/10.0.046; Profile\/MIDP-2.0 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE52-1\/052.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.2",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE52-1\/@version@; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.26 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00\/031.022; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.3.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00.2\/081.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.32 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; U; Series60\/3.2 NokiaN79-1\/32.001; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; U; Series60\/3.2 Nokia6220c-1\/06.101; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/413 (KHTML, like Gecko) Safari\/413",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00.2\/071.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.26 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaE72-1\/081.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.32 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.3; Series60\/3.2 NokiaC5-00\/061.005; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.2 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaX6-00\/40.0.002; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gb",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5800d-1\/60.0.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaC5-03\/12.0.023; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.9 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5228\/40.1.003; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.7.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5230\/51.0.002; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.33 Mobile Safari\/533.4 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 Nokia5530c-2\/32.0.007; Profile\/MIDP-2.1 Configuration\/CLDC-1.1 ) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 BrowserNG\/7.2.6.9 3gpp-gba",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaN97-1\/21.0.045; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) BrowserNG\/7.1.4",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (SymbianOS\/9.4; Series60\/5.0 NokiaN97-4\/30.0.004; Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/533.4 (KHTML, like Gecko) NokiaBrowser\/7.3.1.28 3gpp-gba",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Symbian": "9.4",
+                "Webkit": "533.4",
+                "NokiaBrowser": "7.3.1.28"
+            },
+            "model": "NokiaN97-4"
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 7 Mozart T8698)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; 710)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800C)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 800C; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; 900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; HD7 T9292)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; LG E-900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 610)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; T-Mobile)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 710; Vodafone)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800) UP.Link\/5.1.2.6",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; Orange)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; SFR)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; T-Mobile)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 800; vodafone)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Lumia 800c)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Lumia 900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Lumia 920)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; NOKIA; Lumia 920)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "IE": "10.0",
+                "Windows Phone OS": "8.0",
+                "Trident": "6.0"
+            },
+            "model": "Lumia 920"
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; lumia800)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 610)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 710)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 800)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 800C)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; NOKIA; Nokia 900)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; Nokia)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; SGH-i917)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Nokia",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Nokia; TITAN X310e)",
+            "mobile": true,
+            "tablet": false,
+            "version": {
+                "Windows Phone OS": "7.5",
+                "Trident": "5.0"
+            },
+            "model": "TITAN X310e"
+        },
+        {
+            "vendor": "OverMax",
+            "user_agent": "OV-SteelCore(B) Mozilla\/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit\/534.46 (KHTML, like Gecko) Version\/5.1 Mobile\/9A405 Safari\/7534.48.3",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "OverMax",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-SteelCore Build\/ICS.g08refem611.20121010) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "YONESTablet",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; pl-pl; BC1077 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "PANTECH-C790\/JAUS08312009 Browser\/Obigo\/Q05A Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; ko-kr; SKY IM-A600S Build\/FRG83) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; ADR8995 4G Build\/GRI40) AppleWebKit\/533.1 (KHTML like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Pantech",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-us; PantechP4100 Build\/HTK75) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Opera\/9.70 (Linux armv6l ; U; CE-HTML\/1.0 NETTV\/2.0.2; en) Presto\/2.2.1",
+            "tv": true
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Opera\/9.80 (Linux armv6l ; U; CE-HTML\/1.0 NETTV\/3.0.1;; en) Presto\/2.6.33 Version\/10.60",
+            "tv": true
+        },
+        {
+            "vendor": "Philips",
+            "user_agent": "Opera\/9.80 (Linux mips; HbbTV\/1.2.1 (; Philips; ; ; ; ) CE-HTML\/1.0 NETTV\/4.2.0 PHILIPSTV\/1.1.1 Firmware\/171.56.0 (PhilipsTV, 1.1.1,) en) Presto\/2.12.362 Version\/12.11",
+            "tv": true
+        },
+        {
+            "vendor": "PointOfView",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; POV_TAB-PROTAB30-IPS10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Prestigio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; PMP5297C_QUAD Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Prestigio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; sk-sk; PMP7100D3G Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            },
+            "model": "PMP7100D3G"
+        },
+        {
+            "vendor": "Prestigio",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; sk-sk; PMP7280C3G Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 MobilSafari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "PROSCAN",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; PLT8088 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "PyleAudio",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; PTBL92BC Build\/IMM76D) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.4",
+                "Build": "IMM76D",
+                "Webkit": "537.36",
+                "Chrome": "31.0.1650.59"
+            }
+        },
+        {
+            "vendor": "RockChip",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2.1; hu-hu; RK2818, Build\/MASTER) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "RockChip",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android Android 2.1-RK2818-1.0.0; zh-cn; MD701 Build\/ECLAIR) AppleWebKit\/530.17 (KHTML like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "RossMoor",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; ru-ru; RM-790 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "QMobile",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-us; A2 Build\/GRK39F) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Samsung",
+            "user_agent": "HbbTV\/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit",
+            "tv": true
+        },
+        {
+            "vendor": "Samsung",
+            "user_agent": "Mozilla\/5.0 (SmartHub; SMART-TV; U; Linux\/SmartTV) AppleWebKit\/531.2+ (KHTML, like Gecko) WebBrowser\/1.0 SmartTV Safari\/531.2+",
+            "tv": true
+        },
+        {
+            "vendor": "Samsung",
+            "user_agent": "Mozilla\/5.0 (SMART-TV; X11; Linux i686) AppleWebKit\/535.20+ (KHTML, like Gecko) Version\/5.0 Safari\/535.20+",
+            "tv": true
+        },
+        {
+            "vendor": "Samsung",
+            "user_agent": "Mozilla\/5.0 (SmartHub; SMART-TV; U; Linux\/SmartTV; Maple2012)",
+            "tv": true
+        },
+        {
+            "vendor": "simvalley",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; de-de; SP-80 Build\/GRJ22) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonK800i\/R1AA Browser\/NetFront\/3.3 Profile\/MIDP-2.0 Configuration\/CLDC-1.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; es-ar; SonyEricssonE15a Build\/2.0.1.A.0.47) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.1-update1; pt-br; SonyEricssonU20a Build\/2.1.1.A.0.6) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonX10i Build\/3.0.1.G.0.75) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; SonyEricssonST18i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; hr-hr; SonyEricssonST15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; sk-sk; SonyEricssonLT15i Build\/4.0.2.A.0.62) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; th-th; SonyEricssonST27i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; de-de; SonyEricssonST25i Build\/6.0.B.3.184) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; pt-br; Xperia Tablet S Build\/TID0092) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "TID0092",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; LT18i Build\/4.1.A.0.562) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; Sony Tablet S Build\/TISU0R0110) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; es-es; Sony Tablet S Build\/TISU0143) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; SonyEricssonLT18i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; fr-ch; SonyEricssonSK17i Build\/4.1.B.0.587) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT26i Build\/6.1.A.2.45) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT22i Build\/6.1.B.0.544) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; vi-vn; SonyEricssonLT22i Build\/6.1.B.0.544) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.5.5) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; ST23i Build\/11.0.A.2.10) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; LT28h Build\/6.1.E.3.7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.94 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; SGPT13 Build\/TJDS0170) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; ja-jp; SonySO-03E Build\/10.1.E.0.265) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.2",
+                "Build": "10.1.E.0.265",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.2; LT26w Build\/6.2.B.1.96) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/29.0.1547.72 Mobile Safari\/537.36",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; SGP321 Build\/10.3.1.A.0.33) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "10.3.1.A.0.33",
+                "Webkit": "537.31",
+                "Chrome": "26.0.1410.58"
+            }
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonU5i\/R2CA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "SonyEricssonU5i\/R2AA; Mozilla\/5.0 (SymbianOS\/9.4; U; Series60\/5.0 Profile\/MIDP-2.1 Configuration\/CLDC-1.1) AppleWebKit\/525 (KHTML, like Gecko) Version\/3.0 Safari\/525",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Mozilla\/4.0 (PDA; PalmOS\/sony\/model prmr\/Revision:1.1.54 (en)) NetFront\/3.0",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00",
+            "tv": true
+        },
+        {
+            "vendor": "Sony",
+            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
+            "tv": true
+        },
+        {
+            "vendor": "Panasonic",
+            "user_agent": "Mozilla\/5.0 (FreeBSD; U; Viera; ja-JP) AppleWebKit\/535.1 (KHTML, like Gecko) Viera\/1.2.4 Chrome\/14.0.835.202 Safari\/535.1",
+            "tv": true
+        },
+        {
+            "vendor": "Roku",
+            "user_agent": "Roku\/DVP-5.2 (025.02E03197A)",
+            "tv": true
+        },
+        {
+            "vendor": "Roku",
+            "user_agent": "Roku\/DVP-5.0 (025.00E08043A)",
+            "tv": true
+        },
+        {
+            "vendor": "Sharp",
+            "user_agent": "Mozilla\/5.0 (DTV) AppleWebKit\/531.2  (KHTML, like Gecko) AQUOSBrowser\/1.0 (US00DTV;V;0001;0001)",
+            "tv": true
+        },
+        {
+            "vendor": "Sharp",
+            "user_agent": "Mozilla\/5.0 (DTV) AppleWebKit\/531.2+ (KHTML, like Gecko) Espial\/6.0.4 AQUOSBrowser\/1.0 (CH00DTV;V;0001;0001)",
+            "tv": true
+        },
+        {
+            "vendor": "Sharp",
+            "user_agent": "Opera\/9.80 (Linux armv6l; U; en) Presto\/2.8.115 Version\/11.10 AQUOS-AS\/1.0 LC-40LE835X",
+            "tv": true
+        },
+        {
+            "vendor": "Sharp",
+            "user_agent": "Mozilla\/5.0 (DTV) AppleWebKit\/531.2+ (KHTML, like Gecko) Espial\/6.1.5 AQUOSBrowser\/2.0 (US01DTV;V;0001;0001)",
+            "tv": true
+        },
+        {
+            "vendor": "TechniSat",
+            "user_agent": "Opera\/9.80 (Linux sh4; U; HbbTV\/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S; de) Presto\/2.9.167 Version\/11.50",
+            "tv": true
+        },
+        {
+            "vendor": "Technicolor",
+            "user_agent": "Technicolor_",
+            "tv": true
+        },
+        {
+            "vendor": "Toshiba",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; TOSHIBA; TSUNAGI)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Toshiba",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; it-it; TOSHIBA_FOLIO_AND_A Build\/TOSHIBA_FOLIO_AND_A) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.2",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Smart",
+            "user_agent": "Mozilla\/5.0 (Linux mipsel; U; HbbTV\/1.1.1 (; smart; 40PX200; 0.7.3.0.; t12; ) ; AppleWebKit\/534.1 (KHTML, like Gec",
+            "tv": true
+        },
+        {
+            "vendor": "TV2N",
+            "user_agent": "Mozilla\/5.0 (Linux mipsel; U; HbbTV\/1.1.1 (; tv2n; 40PX200; 0.7.3.0.; t12; ) ; AppleWebKit\/534.1 (KHTML, like Gec",
+            "tv": true
+        },
+        {
+            "vendor": "Winbox",
+            "user_agent": "Winbox Evo2",
+            "tv": true
+        },
+        {
+            "vendor": "Dune HD",
+            "user_agent": "DuneHD\/",
+            "tv": true
+        },
+        {
+            "vendor": "Bewatec",
+            "user_agent": "MediStream",
+            "tv": true
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Ubuntu Chromium\/32.0.1700.102 Chrome\/32.0.1700.102 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko\/20100101 Firefox\/24.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:18.0) Gecko\/20100101 Firefox\/18.0 AlexaToolbar\/psPCtGhf-2.2",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:22.0) Gecko\/20100101 Firefox\/22.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux ppc; rv:17.0) Gecko\/20130626 Firefox\/17.0 Iceweasel\/17.0.7",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; Linux) AppleWebKit\/535.22+ Midori\/0.4",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Macintosh; U; Intel Mac OS X; en-us) AppleWebKit\/535+ (KHTML, like Gecko) Version\/5.0 Safari\/535.20+ Midori\/0.4",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/28.0.1500.20 Safari\/537.36  OPR\/15.0.1147.18 (Edition Next)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.94 Safari\/537.36",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 5.2; WOW64; rv:21.0) Gecko\/20100101 Firefox\/21.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Windows NT 5.2; WOW64) Presto\/2.12.388 Version\/12.14",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64; rv:19.0) Gecko\/20100101 Firefox\/19.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (X11; FreeBSD amd64; rv:14.0) Gecko\/20100101 Firefox\/14.0.1",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Win64; x64; Trident\/6.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET CLR 2.0.50727; Tablet PC 2.0; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; MANMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident\/6.0; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident\/6.0; Touch; MASMJS)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Windows NT 6.2; WOW64; MRA 8.0 (build 5784)) Presto\/2.12.388 Version\/12.11",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident\/6.0)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; Trident\/7.0; rv 11.0) like Gecko",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.3; WOW64; Trident\/7.0; Touch; rv:11.0) like Gecko",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Mozilla\/5.0 (Unknown; Linux armv7l) AppleWebKit\/537.1+ (KHTML, like Gecko) Safari\/537.1+ HbbTV\/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "HbbTV\/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Other",
+            "user_agent": "Opera\/9.80 (Linux armv7l; HbbTV\/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto\/2.12.362 Version\/12.11",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Skk",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1; en-us; CYCLOPS Build\/F10) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee_Tab903 Build\/JRO03H) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "537.36"
+            }
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.1.1; eZee'Tab785 Build\/JRO03C) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.59 Safari\/537.36",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03C",
+                "Webkit": "537.36"
+            }
+        },
+        {
+            "vendor": "Storex",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; eZee'Tab971 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.0.3",
+                "Build": "IML74K",
+                "Webkit": "535.19"
+            }
+        },
+        {
+            "vendor": "Tecno",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; TECNO P9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Telstra",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.7; en-au; T-Hub2 Build\/TVA301TELBG3) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "texet",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.4; ru-ru; TM-7021 Build\/GB.m1ref.20120116) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "2.3.4",
+                "Webkit": "533.1",
+                "Safari": "4.0"
+            },
+            "model": "TM-7021"
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 8.9 Build\/JDQ39) AppleWebKit\/534.30 (KHTML like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Chrome\/31.0.1650.57 Safari\/537.36 OPR\/18.0.1290.67495",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Tolino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; de-de; tolino tab 7 Build\/JDQ39) AppleWebkit\/537.36 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Trekstor",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.2.2; ST70408-1 Build\/JDQ39) AppleWebKit\/537.31 (KHTML, like Gecko) Chrome\/26.0.1410.58 Safari\/537.31",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.2.2",
+                "Build": "JDQ39",
+                "Webkit": "537.31",
+                "Chrome": "26.0.1410.58"
+            }
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-gb; V97 HD Build\/LR-97JC) Apple WebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; Visture V4 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V4 HD Build\/Visture V4 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; es-es; Visture V5 HD Build\/Visture V5 HD) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Visture",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; ru-ru; Visture V10 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; VS-TOUCHPAD 9 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166 Mobile Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; Versus Touchpad 9.7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; CnM-TOUCHPAD7 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 BMID\/E67A45B1AB",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; CnM TouchPad 7DC Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30 TwonkyBeamBrowser\/3.3.5-95 (Android 4.1.1; rockchip CnM TouchPad 7DC Build\/meizhi_V2.80.wifi8723.20121225.b11c800)",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "OneBrowser\/3.5\/Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Versus",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; TOUCHTAB Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true,
+            "version": {
+                "Android": "4.1.1",
+                "Build": "JRO03H",
+                "Webkit": "534.30",
+                "Safari": "4.0"
+            }
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; hu-hu; SmartTab10-MSM8260-V02d-Dec022011-Vodafone-HU) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; SmartTabII10 Build\/IML74K) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vodafone",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; SmartTAB 1002 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vonino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.2; en-us; Sirius_Evo_QS Build\/JDQ39) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Vonino",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-gb; Q8 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1;zh-cn; ZTE V987 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30;",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.5; pt-pt; Blade Build\/tejosunhsine) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; N880e_Dawoer_Fulllock; China Telecom)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; V965W)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "ZTE",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; ZTE; Windows Phone - Internet 7; SFR)",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Zync",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us ; Z909 Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1\/UCBrowser\/8.4.1.204\/145\/444",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (Nintendo WiiU) AppleWebKit\/534.52 (KHTML, like Gecko) NX\/{Version No} NintendoBrowser\/{Version No}.US",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (PLAYSTATION 3 4.21) AppleWebKit\/531.22.8 (KHTML, like Gecko)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Console",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident\/5.0; Xbox)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; ALUMIUM10 Build\/IML74K) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.99 Safari\/537.36",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2.1; en-us; JY-G3 Build\/JOP40D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; hu-hu; M758A Build\/JRO03C) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; EVOTAB Build\/IMM76I) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30",
+            "mobile": true,
+            "tablet": true
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Java\/1.6.0_22",
+            "mobile": false,
+            "tablet": false,
+            "version": {
+                "Java": "1.6.0_22"
+            }
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/6.5.29260\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.5.27452\/29.3417; U; ru) Presto\/2.8.119 Version\/11.10",
+            "mobile": true,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1; WOW64) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.60 Safari\/537.17 OPR\/14.0.1025.52315",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (X11; CrOS armv7l 4920.83.0) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/32.0.1700.103 Safari\/537.36"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit\/533.17.9 (KHTML, like Gecko) Version\/5.0.2 Mobile\/8H7 Safari\/6533.18.5"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-I9070 Build\/JZO54K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android 2.3.7; Linux; Opera Mobi\/46154) Presto\/2.11.355 Version\/12.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; it-it; DATAM819HD_C Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; nl-nl; SGPT12 Build\/TID0142) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; cm_tenderloin Build\/IMM76L; CyanogenMod-9) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; fr-fr; A210 Build\/JRO03H) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Version\/6.0 Mobile\/10B141 Safari\/8536.25"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; en-gb; GT-I8150 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit\/536.26 (KHTML, like Gecko) Mercury\/7.2 Mobile\/10A523 Safari\/8536.25"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android 2.3.7; Linux; Opera Tablet\/46154) Presto\/2.11.355 Version\/12.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.2; en-us; sdk Build\/MASTER) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-us; GT-P7510 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (X11; Linux zbov) Presto\/2.11.355 Version\/12.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.4; en-gb; TOUCHPAD 7 Build\/IMM76D) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (iPhone; U; CPU OS 4_2_1 like Mac OS X) AppleWebKit\/532.9 (KHTML, like Gecko) Version\/5.0.3 Mobile\/8B5097d Safari\/6531.22.7"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-gb; SGPT12 Build\/TID0142) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Nintendo 3DS; U; ; en) Version\/1.7498.US"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.0.6_b1; ru-ru Build\/ECLAIR) AppleWebKit\/530.17 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/530.17"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.4; z1000 Build\/IMM76D) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; Android 4.0.3; cm_tenderloin Build\/GWK74) AppleWebKit\/535.19 (KHTML, like Gecko) Chrome\/18.0.1025.166  Safari\/535.19"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.3; en-us; Android for Techvision TV1T808 Board Build\/GRI40) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "BlackBerry8520\/5.0.0.592 Profile\/MIDP-2.1 Configuration\/CLDC-1.1 VendorID\/136"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.2) AppleWebKit\/537.17 (KHTML, like Gecko) Chrome\/24.0.1312.56 Safari\/537.17"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.1; ru-ru; LG-V900 Build\/HMJ37) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident\/6.0; IEMobile\/10.0; ARM; Touch; HTC; Windows Phone 8S by HTC)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (PLAYSTATION 3 4.11) AppleWebKit\/531.22.8 (KHTML, like Gecko)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2; ru-ru; V9S_V1.4) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.2; es-es; Broncho N701 Build\/FRF91) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch; WebView\/1.0)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; Next7P12 Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (X11; Linux zbov) Presto\/2.11.355 Version\/12.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident\/6.0; Touch)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 2.3.6; es-es; SAMSUNG GT-S5830\/S5830BUKT2 Build\/GINGERBREAD) AppleWebKit\/533.1 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/533.1"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 3.2.1; en-gb;HTC_Flyer_P512 Build\/HTK75C) AppleWebKit\/534.13 (KHTML, like Gecko) Version\/4.0 Safari\/534.13"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-us; full Android on Microsoft Windows, pad, pc, n*books Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Linux mips; U; InettvBrowser\/2.2 (00014A;SonyDTV115;0002;0100) KDL40EX720; CC\/BEL; en) Presto\/2.7.61 Version\/11.00"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Mobile; rv:18.0) Gecko\/18.0 Firefox\/18.0"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Windows NT 6.1) AppleWebKit\/535.12 (KHTML, like Gecko) Maxthon\/3.0 Chrome\/18.0.966.0 Safari\/535.12"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Windows NT 5.1; U; Edition Yx; ru) Presto\/2.10.289 Version\/12.02"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.2; en-us; sdk Build\/JB_MR1) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "PalmCentro\/v0001 Mozilla\/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource\/Palm-D061; Blazer\/4.5) 16;320x320"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; Microsoft; XDeviceEmulator)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident\/5.0; IEMobile\/9.0; MAL; N880E; China Telecom)"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Series 60; Opera Mini\/7.0.29482\/28.2859; U; ru) Presto\/2.8.119 Version\/11.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (S60; SymbOS; Opera Mobi\/SYB-1202242143; U; en-GB) Presto\/2.10.254 Version\/12.00"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.0.3; en-au; 97D Build\/IML74K) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Safari\/534.30"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/7.0.29952\/28.2647; U; ru) Presto\/2.8.119 Version\/11.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android; Opera Mini\/6.1.25375\/28.2555; U; en) Presto\/2.8.119 Version\/11.10"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Mac OS X; Opera Tablet\/35779; U; en) Presto\/2.10.254 Version\/12.00"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:10.0.4) Gecko\/10.0.4 Firefox\/10.0.4 Fennec\/10.0.4"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Android; Tablet; rv:18.0) Gecko\/18.0 Firefox\/18.0"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Linux armv7l; Maemo; Opera Mobi\/14; U; en) Presto\/2.9.201 Version\/11.50"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Opera\/9.80 (Android 2.2.1; Linux; Opera Mobi\/ADR-1207201819; U; en) Presto\/2.10.254 Version\/12.00"
+        },
+        {
+            "vendor": "Generic",
+            "user_agent": "Mozilla\/5.0 (Linux; U; Android 4.1.1; en-us; sdk Build\/JRO03E) AppleWebKit\/534.30 (KHTML, like Gecko) Version\/4.0 Mobile Safari\/534.30"
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Mozilla\/5.0 (compatible; Googlebot\/2.1; +http:\/\/www.google.com\/bot.html)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "grub-client-1.5.3; (grub-client-1.5.3; Crawl your own stuff with http:\/\/grub.org)",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Googlebot-Image\/1.0",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "Python-urllib\/2.5",
+            "mobile": false,
+            "tablet": false
+        },
+        {
+            "vendor": "Bot",
+            "user_agent": "facebookexternalhit\/1.0 (+http:\/\/www.facebook.com\/externalhit_uatext.php)",
+            "mobile": false,
+            "tablet": false
+        }
+    ]
+}


### PR DESCRIPTION
Hi !

First, thanks for this great library!

TV detection is important to us, so I've implemented it, keeping the same detection patterns as for mobile and tablets (btw, the architecture makes it very easy to add new detections :+1:).

I know there's already a discussion about this (#203) but we needed this _now_ so I went ahead and added it to fulfil our needs. :)

Are you interested in this addition? If yes, please let me know if there's anything I can tweak to make this PR acceptable (if it's not already).

Cheers!
